### PR TITLE
add support for prometheus metrics

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -16,6 +16,7 @@
 # secret_key = "CHANGE_ME" # env variable: SERVER_SECRET_KEY
 # verify_requests = false
 # encrypt_query_params = false # env variable: SERVER_ENCRYPT_QUERY_PARAMS
+# enable_metrics = false # env variable: ENABLE_METRICS
  
 # [cache]
 # enabled = true

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -16,7 +16,7 @@
 # secret_key = "CHANGE_ME" # env variable: SERVER_SECRET_KEY
 # verify_requests = false
 # encrypt_query_params = false # env variable: SERVER_ENCRYPT_QUERY_PARAMS
-# enable_metrics = false # env variable: ENABLE_METRICS
+# enable_metrics = false # env variable: SERVER_ENABLE_METRICS
  
 # [cache]
 # enabled = true

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
   "imports": {
     "hono": "jsr:@hono/hono@4.7.4",
     "@std/toml": "jsr:@std/toml@1.0.2",
-    "prom-client": "npm:prom-client@15.1.3",
+    "prom-client": "https://esm.sh/prom-client@15.1.3",
     "youtubei.js": "https://raw.githubusercontent.com/LuanRT/YouTube.js/refs/tags/v13.3.0-deno/deno.ts",
     "youtubei.js/Utils": "https://raw.githubusercontent.com/LuanRT/YouTube.js/refs/tags/v13.3.0-deno/deno/src/utils/Utils.ts",
     "youtubei.js/NavigationEndpoint": "https://raw.githubusercontent.com/LuanRT/YouTube.js/refs/tags/v13.3.0-deno/deno/src/parser/classes/NavigationEndpoint.ts",

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,7 @@
   "imports": {
     "hono": "jsr:@hono/hono@4.7.4",
     "@std/toml": "jsr:@std/toml@1.0.2",
+    "prom-client": "npm:prom-client@15.1.3",
     "youtubei.js": "https://raw.githubusercontent.com/LuanRT/YouTube.js/refs/tags/v13.3.0-deno/deno.ts",
     "youtubei.js/Utils": "https://raw.githubusercontent.com/LuanRT/YouTube.js/refs/tags/v13.3.0-deno/deno/src/utils/Utils.ts",
     "youtubei.js/NavigationEndpoint": "https://raw.githubusercontent.com/LuanRT/YouTube.js/refs/tags/v13.3.0-deno/deno/src/parser/classes/NavigationEndpoint.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -15,8 +15,7 @@
     "npm:@bufbuild/protobuf@2": "2.2.4",
     "npm:@types/estree@^1.0.6": "1.0.7",
     "npm:acorn@^8.8.0": "8.14.1",
-    "npm:jsdom@26.0.0": "26.0.0",
-    "npm:prom-client@15.1.3": "15.1.3"
+    "npm:jsdom@26.0.0": "26.0.0"
   },
   "jsr": {
     "@hono/hono@4.7.4": {
@@ -102,9 +101,6 @@
     "@csstools/css-tokenizer@3.0.3": {
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw=="
     },
-    "@opentelemetry/api@1.9.0": {
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
-    },
     "@types/estree@1.0.7": {
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
     },
@@ -116,9 +112,6 @@
     },
     "asynckit@0.4.0": {
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "bintrees@1.0.2": {
-      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "call-bind-apply-helpers@1.0.2": {
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
@@ -325,13 +318,6 @@
         "entities"
       ]
     },
-    "prom-client@15.1.3": {
-      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
-      "dependencies": [
-        "@opentelemetry/api",
-        "tdigest"
-      ]
-    },
     "punycode@2.3.1": {
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
@@ -349,12 +335,6 @@
     },
     "symbol-tree@3.2.4": {
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
-    },
-    "tdigest@0.1.2": {
-      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
-      "dependencies": [
-        "bintrees"
-      ]
     },
     "tldts-core@6.1.84": {
       "integrity": "sha512-NaQa1W76W2aCGjXybvnMYzGSM4x8fvG2AN/pla7qxcg0ZHbooOPhA8kctmOZUDfZyhDL27OGNbwAeig8P4p1vg=="
@@ -413,7 +393,9 @@
     }
   },
   "redirects": {
-    "https://esm.sh/@types/estree@1.0.6": "https://esm.sh/@types/estree@1.0.6/index.d.ts"
+    "https://esm.sh/@opentelemetry/api@^1.4.0?target=denonext": "https://esm.sh/@opentelemetry/api@1.9.0?target=denonext",
+    "https://esm.sh/@types/estree@1.0.6": "https://esm.sh/@types/estree@1.0.6/index.d.ts",
+    "https://esm.sh/tdigest@^0.1.1?target=denonext": "https://esm.sh/tdigest@0.1.2?target=denonext"
   },
   "remote": {
     "https://deno.land/std@0.159.0/encoding/ascii85.ts": "f2b9cb8da1a55b3f120d3de2e78ac993183a4fd00dfa9cb03b51cf3a75bc0baa",
@@ -469,8 +451,15 @@
     "https://esm.sh/@bufbuild/protobuf@2.0.0/denonext/dist/esm/wkt/wrappers.mjs": "2fdb6acdda91c53c238b51c5ea6ef8def5b4e9871f93c439ab835c0a9f1e6070",
     "https://esm.sh/@bufbuild/protobuf@2.0.0/denonext/wire.mjs": "791ca43f39084f37fabf37bcd77c788861bce7cc3d0d8528dc61ec9559956f46",
     "https://esm.sh/@bufbuild/protobuf@2.0.0/wire": "eb1be07dad5823fc419cc9e6f62077a70962ce42facb1a5240b7d5c3674e852f",
+    "https://esm.sh/@opentelemetry/api@1.9.0/denonext/api.mjs": "d9ede8bd549446ae09ea5af32de6b8b7d4ca13bcbd90eb39ae890c0fea78f618",
+    "https://esm.sh/@opentelemetry/api@1.9.0?target=denonext": "6969eed0eafa68f1c525555a674daaa3143bb7f41f531bf7c1c9967e32419038",
     "https://esm.sh/bgutils-js@3.2.0": "9691c575e7f81d8c2652260f59356b5de97a242fc8b464dbba880a543f6ce075",
     "https://esm.sh/bgutils-js@3.2.0/denonext/bgutils-js.mjs": "9acd0267c5bf7273ba122a295f97795cb81d0f6d001db708c92548ac82977f93",
+    "https://esm.sh/bintrees@1.0.2/denonext/bintrees.mjs": "a60dece304ed0119eeb04d32fcc783ef3adcdce64ef64c7f6d07af54ca078bac",
+    "https://esm.sh/prom-client@15.1.3": "8dfdb71d7bce0684fcdc43210c6ea05a645b0a6c50e142d122aed6f341e1ebf7",
+    "https://esm.sh/prom-client@15.1.3/denonext/prom-client.mjs": "64d877f1354ec54fabbdaf22973de781d640726a456805f6cbccc8ba60ecc153",
+    "https://esm.sh/tdigest@0.1.2/denonext/tdigest.mjs": "379f502069e3a3efb26dcc3e72a117e2f9c78e4ce3bf6abd6944b4bf8598cb0a",
+    "https://esm.sh/tdigest@0.1.2?target=denonext": "53806e3c28da0241f722b9d6d921cb4f4fcb628bd5af56d0315acf4865675c6c",
     "https://raw.githubusercontent.com/LuanRT/YouTube.js/refs/tags/v13.1.0-deno/deno.ts": "f913bfdb3c66b2330fa8b531bd1e291437b836c9fbf002b9ae044bf14e1f397c",
     "https://raw.githubusercontent.com/LuanRT/YouTube.js/refs/tags/v13.1.0-deno/deno/package.json": "4e1d16c0f95a2b58dc6dba7e0fe969b800794a6040ae02116e14eae2444e4429",
     "https://raw.githubusercontent.com/LuanRT/YouTube.js/refs/tags/v13.1.0-deno/deno/protos/generated/misc/common.ts": "7d6ca8d7cd7eafe1f8d5ddc11c440566c418aeaf2d8a03a72eced7466a691039",
@@ -3043,8 +3032,7 @@
       "jsr:@std/fs@1.0.14",
       "jsr:@std/path@1.0.8",
       "jsr:@std/toml@1.0.2",
-      "npm:jsdom@26.0.0",
-      "npm:prom-client@15.1.3"
+      "npm:jsdom@26.0.0"
     ]
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -15,7 +15,8 @@
     "npm:@bufbuild/protobuf@2": "2.2.4",
     "npm:@types/estree@^1.0.6": "1.0.7",
     "npm:acorn@^8.8.0": "8.14.1",
-    "npm:jsdom@26.0.0": "26.0.0"
+    "npm:jsdom@26.0.0": "26.0.0",
+    "npm:prom-client@15.1.3": "15.1.3"
   },
   "jsr": {
     "@hono/hono@4.7.4": {
@@ -101,6 +102,9 @@
     "@csstools/css-tokenizer@3.0.3": {
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw=="
     },
+    "@opentelemetry/api@1.9.0": {
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
+    },
     "@types/estree@1.0.7": {
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
     },
@@ -112,6 +116,9 @@
     },
     "asynckit@0.4.0": {
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "bintrees@1.0.2": {
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "call-bind-apply-helpers@1.0.2": {
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
@@ -318,6 +325,13 @@
         "entities"
       ]
     },
+    "prom-client@15.1.3": {
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "tdigest"
+      ]
+    },
     "punycode@2.3.1": {
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
@@ -335,6 +349,12 @@
     },
     "symbol-tree@3.2.4": {
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "tdigest@0.1.2": {
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": [
+        "bintrees"
+      ]
     },
     "tldts-core@6.1.84": {
       "integrity": "sha512-NaQa1W76W2aCGjXybvnMYzGSM4x8fvG2AN/pla7qxcg0ZHbooOPhA8kctmOZUDfZyhDL27OGNbwAeig8P4p1vg=="
@@ -3023,7 +3043,8 @@
       "jsr:@std/fs@1.0.14",
       "jsr:@std/path@1.0.8",
       "jsr:@std/toml@1.0.2",
-      "npm:jsdom@26.0.0"
+      "npm:jsdom@26.0.0",
+      "npm:prom-client@15.1.3"
     ]
   }
 }

--- a/grafana_dashboard.json
+++ b/grafana_dashboard.json
@@ -314,7 +314,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 142
+            "y": 2
           },
           "id": 15,
           "options": {
@@ -349,6 +349,110 @@
             }
           ],
           "title": "Unknown Status Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bdy7ccu1ntm2oa"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 22,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "bdy7ccu1ntm2oa"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "rate(invidious_companion_innertube_error_status_loginRequired_total[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "\"LOGIN_REQUIRED\" Rate",
           "type": "timeseries"
         }
       ],
@@ -432,7 +536,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 23
           },
           "id": 14,
           "options": {
@@ -536,7 +640,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 23
           },
           "id": 4,
           "options": {
@@ -651,7 +755,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 34
           },
           "id": 21,
           "options": {
@@ -752,7 +856,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 34
           },
           "id": 6,
           "options": {
@@ -870,7 +974,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 165
+            "y": 185
           },
           "id": 16,
           "options": {
@@ -927,6 +1031,6 @@
   "timezone": "browser",
   "title": "Invidious Companion",
   "uid": "1-0-0",
-  "version": 18,
+  "version": 20,
   "weekStart": ""
 }

--- a/grafana_dashboard.json
+++ b/grafana_dashboard.json
@@ -1,0 +1,932 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 38,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 18,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bdy7ccu1ntm2oa"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 12,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "bdy7ccu1ntm2oa"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(invidious_companion_innertube_successful_request_total[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Successful Requests Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bdy7ccu1ntm2oa"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 13,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "bdy7ccu1ntm2oa"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(invidious_companion_innertube_failed_request_total[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Failed Requests Rate",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Requests",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 19,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bdy7ccu1ntm2oa"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 142
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "bdy7ccu1ntm2oa"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(invidious_companion_innertube_error_status_unknown_total[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Unknown Status Rate",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Status",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 8,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bdy7ccu1ntm2oa"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 14,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "bdy7ccu1ntm2oa"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(invidious_companion_innertube_error_reason_unknown_total[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Unknown Reason Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bdy7ccu1ntm2oa"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "bdy7ccu1ntm2oa"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(invidious_companion_innertube_error_reason_SignIn_total[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "\"Sign in to confirm you’re not a bot.\" Rate",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Reasons",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 9,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bdy7ccu1ntm2oa"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "id": 21,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "bdy7ccu1ntm2oa"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "rate(invidious_companion_innertube_error_subreason_unknown_total[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Unknown Subreason Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bdy7ccu1ntm2oa"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "bdy7ccu1ntm2oa"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(invidious_companion_innertube_error_subreason_ProtectCommunity_total[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "\"This helps protect our community.\" Rate",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Subreasons",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 20,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bdy7ccu1ntm2oa"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 165
+          },
+          "id": 16,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "bdy7ccu1ntm2oa"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(invidious_companion_potoken_generation_failure_total[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "poToken Generation Failure Rate",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Jobs",
+      "type": "row"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Invidious Companion",
+  "uid": "1-0-0",
+  "version": 18,
+  "weekStart": ""
+}

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -13,7 +13,7 @@ const ConfigSchema = z.object({
             Deno.env.get("SERVER_ENCRYPT_QUERY_PARAMS") === "true" || false,
         ),
         enable_metrics: z.boolean().default(
-            Deno.env.get("ENABLE_METRICS") === "true" || false,
+            Deno.env.get("SERVER_ENABLE_METRICS") === "true" || false,
         ),
     }).strict().default({}),
     cache: z.object({

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -12,6 +12,7 @@ const ConfigSchema = z.object({
         encrypt_query_params: z.boolean().default(
             Deno.env.get("SERVER_ENCRYPT_QUERY_PARAMS") === "true" || false,
         ),
+        enable_metrics : z.boolean().default(Deno.env.get("ENABLE_METRICS") === "true" || false)
     }).strict().default({}),
     cache: z.object({
         enabled: z.boolean().default(true),

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -13,7 +13,11 @@ const ConfigSchema = z.object({
             Deno.env.get("SERVER_ENCRYPT_QUERY_PARAMS") === "true" || false,
         ),
         enable_metrics: z.boolean().default(
-            Deno.env.get("SERVER_ENABLE_METRICS") === "true" || false,
+            Deno.env.get("SERVER_ENABLE_METRICS") === "true"
+                ? true
+                : Deno.env.get("SERVER_ENABLE_METRICS") === "false"
+                ? false
+                : false,
         ),
     }).strict().default({}),
     cache: z.object({

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -13,11 +13,7 @@ const ConfigSchema = z.object({
             Deno.env.get("SERVER_ENCRYPT_QUERY_PARAMS") === "true" || false,
         ),
         enable_metrics: z.boolean().default(
-            Deno.env.get("SERVER_ENABLE_METRICS") === "true"
-                ? true
-                : Deno.env.get("SERVER_ENABLE_METRICS") === "false"
-                ? false
-                : false,
+            Deno.env.get("SERVER_ENABLE_METRICS") === "true" || false,
         ),
     }).strict().default({}),
     cache: z.object({

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -12,7 +12,9 @@ const ConfigSchema = z.object({
         encrypt_query_params: z.boolean().default(
             Deno.env.get("SERVER_ENCRYPT_QUERY_PARAMS") === "true" || false,
         ),
-        enable_metrics : z.boolean().default(Deno.env.get("ENABLE_METRICS") === "true" || false)
+        enable_metrics: z.boolean().default(
+            Deno.env.get("ENABLE_METRICS") === "true" || false,
+        ),
     }).strict().default({}),
     cache: z.object({
         enabled: z.boolean().default(true),

--- a/src/lib/helpers/metrics.ts
+++ b/src/lib/helpers/metrics.ts
@@ -36,9 +36,9 @@ export class Metrics {
         "Number of times that an unknown error has been returned by the Innertube API",
     );
 
-    public innertubeSuccessfullRequest = this.createCounter(
-        "innertube_successfull_request",
-        "Number successfull requests made to the Innertube API",
+    public innertubeSuccessfulRequest = this.createCounter(
+        "innertube_successful_request",
+        "Number successful requests made to the Innertube API",
     );
 
     private innertubeFailedRequest = this.createCounter(
@@ -69,7 +69,6 @@ export class Metrics {
         if (hit == false) {
             this.innertubeErrorUnknown.inc();
         }
-        return;
     }
 }
 

--- a/src/lib/helpers/metrics.ts
+++ b/src/lib/helpers/metrics.ts
@@ -1,8 +1,5 @@
 import { IRawResponse } from "youtubei.js";
 import { Counter, Registry } from "prom-client";
-import { Config } from "../helpers/config.ts";
-
-export let metrics: Metrics | undefined;
 
 export class Metrics {
     private METRICS_PREFIX = "invidious_companion_";
@@ -109,11 +106,5 @@ export class Metrics {
                 this.innertubeErrorStatusUnknown.inc();
                 break;
         }
-    }
-}
-
-export function initMetrics(config: Config): void {
-    if (config.server.enable_metrics) {
-        metrics = new Metrics();
     }
 }

--- a/src/lib/helpers/metrics.ts
+++ b/src/lib/helpers/metrics.ts
@@ -55,6 +55,8 @@ export class Metrics {
 
     private checkStatus(videoData: IRawResponse) {
         return {
+            unplayable: videoData.playabilityStatus?.status ===
+                "UNPLAYABLE",
             contentCheckRequired: videoData.playabilityStatus?.status ===
                 "CONTENT_CHECK_REQUIRED",
             loginRequired:
@@ -86,7 +88,7 @@ export class Metrics {
         this.innertubeFailedRequest.inc();
         const status = this.checkStatus(videoData);
 
-        if (status.contentCheckRequired) {
+        if (status.contentCheckRequired || status.unplayable) {
             return;
         }
 

--- a/src/lib/helpers/metrics.ts
+++ b/src/lib/helpers/metrics.ts
@@ -14,42 +14,42 @@ export class Metrics {
     }
 
     public potokenGenerationFailure = this.createCounter(
-        "potoken_generation_failure",
+        "potoken_generation_failure_total",
         "Number of times that the PoToken generation job has failed for whatever reason",
     );
 
     private innertubeErrorStatusUnknown = this.createCounter(
-        "innertube_error_status_unknown",
+        "innertube_error_status_unknown_total",
         "Number of times that an unknown status has been returned by Innertube API",
     );
 
     private innertubeErrorReasonSignIn = this.createCounter(
-        "innertube_error_reason_SignIn",
+        "innertube_error_reason_SignIn_total",
         'Number of times that the message "Sign in to confirm you’re not a bot." has been returned by Innertube API',
     );
 
     private innertubeErrorSubreasonProtectCommunity = this.createCounter(
-        "innertube_error_subreason_ProtectCommunity",
+        "innertube_error_subreason_ProtectCommunity_total",
         'Number of times that the message "This helps protect our community." has been returned by Innertube API',
     );
 
     private innertubeErrorReasonUnknown = this.createCounter(
-        "innertube_error_reason_unknown",
+        "innertube_error_reason_unknown_total",
         "Number of times that an unknown reason has been returned by the Innertube API",
     );
 
     private innertubeErrorSubreasonUnknown = this.createCounter(
-        "innertube_error_subreason_unknown",
+        "innertube_error_subreason_unknown_total",
         "Number of times that an unknown subreason has been returned by the Innertube API",
     );
 
     public innertubeSuccessfulRequest = this.createCounter(
-        "innertube_successful_request",
+        "innertube_successful_request_total",
         "Number successful requests made to the Innertube API",
     );
 
     private innertubeFailedRequest = this.createCounter(
-        "innertube_failed_request",
+        "innertube_failed_request_total",
         "Number failed requests made to the Innertube API for whatever reason",
     );
 

--- a/src/lib/helpers/metrics.ts
+++ b/src/lib/helpers/metrics.ts
@@ -1,0 +1,80 @@
+import { IRawResponse } from "youtubei.js";
+import { Counter, Registry } from "prom-client";
+import { Config } from "../helpers/config.ts";
+
+export let metrics: Metrics | undefined;
+
+export class Metrics {
+    private METRICS_PREFIX = "invidious_companion_";
+    public register = new Registry();
+
+    public createCounter(name: string, help?: string): Counter {
+        return new Counter({
+            name: `${this.METRICS_PREFIX}${name}`,
+            help: help || "No help has been provided for this metric",
+            registers: [this.register],
+        });
+    }
+
+    public potokenGenerationFailure = this.createCounter(
+        "potoken_generation_failure",
+        "Number of times that the PoToken generation job has failed for whatever reason",
+    );
+
+    private innertubeErrorSubreasonProtectCommunity = this.createCounter(
+        "innertube_subreason_ProtectCommunity",
+        'Number of times that the message "This helps protect our community." has been returned by Innertube API',
+    );
+
+    private innertubeErrorReasonSignIn = this.createCounter(
+        "innertube_reason_SignIn",
+        'Number of times that the message "Sign in to confirm you’re not a bot." has been returned by Innertube API',
+    );
+
+    private innertubeErrorUnknown = this.createCounter(
+        "innertube_error_unknown",
+        "Number of times that an unknown error has been returned by the Innertube API",
+    );
+
+    public innertubeSuccessfullRequest = this.createCounter(
+        "innertube_successfull_request",
+        "Number successfull requests made to the Innertube API",
+    );
+
+    private innertubeFailedRequest = this.createCounter(
+        "innertube_failed_request",
+        "Number failed requests made to the Innertube API for whatever reason",
+    );
+
+    public checkInnertubeResponse(videoData: IRawResponse) {
+        this.innertubeFailedRequest.inc();
+        let hit: boolean = false;
+        if (
+            videoData.playabilityStatus?.errorScreen?.playerErrorMessageRenderer
+                ?.subreason?.runs?.[0]?.text?.includes(
+                    "This helps protect our community",
+                )
+        ) {
+            this.innertubeErrorSubreasonProtectCommunity.inc();
+            hit = true;
+        }
+        if (
+            videoData.playabilityStatus?.reason?.includes(
+                "Sign in to confirm you’re not a bot",
+            )
+        ) {
+            this.innertubeErrorReasonSignIn.inc();
+            hit = true;
+        }
+        if (hit == false) {
+            this.innertubeErrorUnknown.inc();
+        }
+        return;
+    }
+}
+
+export function initMetrics(config: Config): void {
+    if (config.server.enable_metrics) {
+        metrics = new Metrics();
+    }
+}

--- a/src/lib/helpers/metrics.ts
+++ b/src/lib/helpers/metrics.ts
@@ -59,33 +59,39 @@ export class Metrics {
     );
 
     private checkStatus(videoData: IRawResponse) {
+        const status = videoData.playabilityStatus?.status;
+
         return {
-            unplayable: videoData.playabilityStatus?.status ===
+            unplayable: status ===
                 "UNPLAYABLE",
-            contentCheckRequired: videoData.playabilityStatus?.status ===
+            contentCheckRequired: status ===
                 "CONTENT_CHECK_REQUIRED",
-            loginRequired:
-                videoData.playabilityStatus?.status === "LOGIN_REQUIRED",
+            loginRequired: status === "LOGIN_REQUIRED",
         };
     }
 
     private checkReason(videoData: IRawResponse) {
+        const reason = videoData.playabilityStatus?.reason;
+
         return {
-            signInToConfirmAge: videoData.playabilityStatus?.reason?.includes(
+            signInToConfirmAge: reason?.includes(
                 "Sign in to confirm your age",
             ),
-            SignInToConfirmBot: videoData.playabilityStatus?.reason?.includes(
+            SignInToConfirmBot: reason?.includes(
                 "Sign in to confirm you’re not a bot",
             ),
         };
     }
 
     private checkSubreason(videoData: IRawResponse) {
+        const subReason = videoData.playabilityStatus?.errorScreen
+            ?.playerErrorMessageRenderer
+            ?.subreason?.runs?.[0]?.text;
+
         return {
-            thisHelpsProtectCommunity: videoData.playabilityStatus?.errorScreen
-                ?.playerErrorMessageRenderer
-                ?.subreason?.runs?.[0]?.text
-                ?.includes("This helps protect our community"),
+            thisHelpsProtectCommunity: subReason?.includes(
+                "This helps protect our community",
+            ),
         };
     }
 

--- a/src/lib/helpers/metrics.ts
+++ b/src/lib/helpers/metrics.ts
@@ -18,6 +18,11 @@ export class Metrics {
         "Number of times that the PoToken generation job has failed for whatever reason",
     );
 
+    private innertubeErrorStatusLoginRequired = this.createCounter(
+        "innertube_error_status_loginRequired_total",
+        'Number of times that the status "LOGIN_REQUIRED" has been returned by Innertube API',
+    );
+
     private innertubeErrorStatusUnknown = this.createCounter(
         "innertube_error_status_unknown_total",
         "Number of times that an unknown status has been returned by Innertube API",
@@ -88,18 +93,15 @@ export class Metrics {
         this.innertubeFailedRequest.inc();
         const status = this.checkStatus(videoData);
 
-        if (status.contentCheckRequired || status.unplayable) {
-            return;
-        }
+        if (status.contentCheckRequired || status.unplayable) return;
 
         if (status.loginRequired) {
+            this.innertubeErrorStatusLoginRequired.inc();
             const reason = this.checkReason(videoData);
 
-            if (reason.signInToConfirmAge) {
-                return;
-            }
+            if (reason.signInToConfirmAge) return;
 
-            if (status.contentCheckRequired) {
+            if (reason.SignInToConfirmBot) {
                 this.innertubeErrorReasonSignIn.inc();
                 const subReason = this.checkSubreason(videoData);
 

--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -148,7 +148,7 @@ export const youtubePlayerParsing = async ({
         }))(videoData);
 
         if (videoData.playabilityStatus?.status == "OK") {
-            metrics?.innertubeSuccessfullRequest.inc();
+            metrics?.innertubeSuccessfulRequest.inc();
             if (cacheEnabled) {
                 (async () => {
                     await kv.set(

--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -2,7 +2,7 @@ import { ApiResponse, Innertube, YT } from "youtubei.js";
 import { generateRandomString } from "youtubei.js/Utils";
 import { compress, decompress } from "brotli";
 import type { BG } from "bgutils";
-import { metrics } from "../helpers/metrics.ts";
+import { Metrics } from "../helpers/metrics.ts";
 let youtubePlayerReqLocation = "youtubePlayerReq";
 if (Deno.env.get("YT_PLAYER_REQ_LOCATION")) {
     if (Deno.env.has("DENO_COMPILED")) {
@@ -25,12 +25,14 @@ export const youtubePlayerParsing = async ({
     videoId,
     config,
     tokenMinter,
+    metrics,
     overrideCache = false,
 }: {
     innertubeClient: Innertube;
     videoId: string;
     config: Config;
     tokenMinter: BG.WebPoMinter;
+    metrics: Metrics | undefined;
     overrideCache?: boolean;
 }): Promise<object> => {
     const cacheEnabled = overrideCache ? false : config.cache.enabled;

--- a/src/lib/jobs/potoken.ts
+++ b/src/lib/jobs/potoken.ts
@@ -7,6 +7,7 @@ import {
     youtubeVideoInfo,
 } from "../helpers/youtubePlayerHandling.ts";
 import type { Config } from "../helpers/config.ts";
+import { Metrics } from "../helpers/metrics.ts";
 let getFetchClientLocation = "getFetchClient";
 if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {
     if (Deno.env.has("DENO_COMPILED")) {
@@ -24,6 +25,7 @@ const { getFetchClient } = await import(getFetchClientLocation);
 export const poTokenGenerate = async (
     innertubeClient: Innertube,
     config: Config,
+    metrics: Metrics | undefined,
 ): Promise<{ innertubeClient: Innertube; tokenMinter: BG.WebPoMinter }> => {
     if (innertubeClient.session.po_token) {
         innertubeClient = await Innertube.create({
@@ -152,6 +154,7 @@ export const poTokenGenerate = async (
             videoId: video.id,
             config,
             tokenMinter: integrityTokenBasedMinter,
+            metrics,
             overrideCache: true,
         });
         const videoInfo = youtubeVideoInfo(

--- a/src/lib/types/HonoVariables.ts
+++ b/src/lib/types/HonoVariables.ts
@@ -1,9 +1,11 @@
 import { Innertube } from "youtubei.js";
 import { BG } from "bgutils";
 import type { Config } from "../helpers/config.ts";
+import { Metrics } from "../helpers/metrics.ts";
 
 export type HonoVariables = {
     innertubeClient: Innertube;
     config: Config;
     tokenMinter: BG.WebPoMinter;
+    metrics: Metrics | undefined;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import type { HonoVariables } from "./lib/types/HonoVariables.ts";
 
 import { parseConfig } from "./lib/helpers/config.ts";
 const config = await parseConfig();
-import { initMetrics, metrics } from "./lib/helpers/metrics.ts"
+import { initMetrics, metrics } from "./lib/helpers/metrics.ts";
 
 let getFetchClientLocation = "getFetchClient";
 if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ if (!innertubeClientOauthEnabled) {
                     ));
                 } catch (err) {
                     metrics?.potokenGenerationFailure.inc();
-                    throw err
+                    throw err;
                 }
             } else {
                 innertubeClient = await Innertube.create({

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,8 +78,9 @@ if (!innertubeClientOauthEnabled) {
                         innertubeClient,
                         config,
                     ));
-                } catch (_) {
+                } catch (err) {
                     metrics?.potokenGenerationFailure.inc();
+                    throw err
                 }
             } else {
                 innertubeClient = await Innertube.create({
@@ -117,6 +118,7 @@ app.use("*", async (c, next) => {
     c.set("innertubeClient", innertubeClient);
     c.set("tokenMinter", tokenMinter);
     c.set("config", config);
+    c.set("metrics", metrics);
     await next();
 });
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -33,5 +33,7 @@ export const routes = (
     app.route("/api/v1/captions", invidiousCaptionsApi);
     app.route("/videoplayback", videoPlaybackProxy);
     app.route("/healthz", health);
-    app.route("/metrics", metrics_);
+    if (config.server.enable_metrics) {
+        app.route("/metrics", metrics_);
+    }
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,6 +10,7 @@ import getDownloadHandler from "./invidious_routes/download.ts";
 import videoPlaybackProxy from "./videoPlaybackProxy.ts";
 import health from "./health.ts";
 import type { Config } from "../lib/helpers/config.ts";
+import metrics_ from "./metrics.ts";
 
 export const routes = (
     app: Hono,
@@ -32,4 +33,5 @@ export const routes = (
     app.route("/api/v1/captions", invidiousCaptionsApi);
     app.route("/videoplayback", videoPlaybackProxy);
     app.route("/healthz", health);
+    app.route("/metrics", metrics_);
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,7 +10,7 @@ import getDownloadHandler from "./invidious_routes/download.ts";
 import videoPlaybackProxy from "./videoPlaybackProxy.ts";
 import health from "./health.ts";
 import type { Config } from "../lib/helpers/config.ts";
-import metrics_ from "./metrics.ts";
+import metrics from "./metrics.ts";
 
 export const routes = (
     app: Hono,
@@ -34,6 +34,6 @@ export const routes = (
     app.route("/videoplayback", videoPlaybackProxy);
     app.route("/healthz", health);
     if (config.server.enable_metrics) {
-        app.route("/metrics", metrics_);
+        app.route("/metrics", metrics);
     }
 };

--- a/src/routes/invidious_routes/captions.ts
+++ b/src/routes/invidious_routes/captions.ts
@@ -19,6 +19,7 @@ const captionsHandler = new Hono<{ Variables: HonoVariables }>();
 captionsHandler.get("/:videoId", async (c) => {
     const { videoId } = c.req.param();
     const config = c.get("config");
+    const metrics = c.get("metrics");
 
     const check = c.req.query("check");
 
@@ -40,6 +41,7 @@ captionsHandler.get("/:videoId", async (c) => {
         innertubeClient,
         videoId,
         config,
+        metrics,
         tokenMinter: c.get("tokenMinter"),
     });
 

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -17,6 +17,7 @@ dashManifest.get("/:videoId", async (c) => {
 
     const innertubeClient = c.get("innertubeClient");
     const config = c.get("config");
+    const metrics = c.get("metrics");
 
     if (config.server.verify_requests && check == undefined) {
         throw new HTTPException(400, {
@@ -35,6 +36,7 @@ dashManifest.get("/:videoId", async (c) => {
         videoId,
         config,
         tokenMinter: c.get("tokenMinter"),
+        metrics,
     });
     const videoInfo = youtubeVideoInfo(
         innertubeClient,

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -21,6 +21,7 @@ latestVersion.get("/", async (c) => {
 
     const innertubeClient = c.get("innertubeClient");
     const config = c.get("config");
+    const metrics = c.get("metrics");
 
     if (config.server.verify_requests && check == undefined) {
         throw new HTTPException(400, {
@@ -39,6 +40,7 @@ latestVersion.get("/", async (c) => {
         videoId: id,
         config,
         tokenMinter: c.get("tokenMinter"),
+        metrics,
     });
     const videoInfo = youtubeVideoInfo(
         innertubeClient,

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -1,0 +1,12 @@
+import { Hono } from "hono";
+import { metrics } from "../lib/helpers/metrics.ts";
+
+const metrics_ = new Hono();
+
+metrics_.get("/", async () => {
+    return new Response(await metrics?.register.metrics(), {
+        headers: { "Content-Type": "text/plain" },
+    });
+});
+
+export default metrics_;

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -1,12 +1,11 @@
 import { Hono } from "hono";
-import { metrics } from "../lib/helpers/metrics.ts";
 
-const metrics_ = new Hono();
+const metrics = new Hono();
 
-metrics_.get("/", async () => {
-    return new Response(await metrics?.register.metrics(), {
+metrics.get("/", async (c) => {
+    return new Response(await c.get("metrics")?.register.metrics(), {
         headers: { "Content-Type": "text/plain" },
     });
 });
 
-export default metrics_;
+export default metrics;

--- a/src/routes/youtube_api_routes/player.ts
+++ b/src/routes/youtube_api_routes/player.ts
@@ -7,6 +7,7 @@ player.post("/player", async (c) => {
     const jsonReq = await c.req.json();
     const innertubeClient = c.get("innertubeClient");
     const config = c.get("config");
+    const metrics = c.get("metrics");
     if (jsonReq.videoId) {
         return c.json(
             await youtubePlayerParsing({
@@ -14,6 +15,7 @@ player.post("/player", async (c) => {
                 videoId: jsonReq.videoId,
                 config,
                 tokenMinter: c.get("tokenMinter"),
+                metrics,
             }),
         );
     }


### PR DESCRIPTION
Useful for troubleshooting blockages in a visual manner using Grafana.

It doesn't count how many times `poTokenGenerate` has failed between lines 69-83, I didn't wanted to touch that much code. But I'll make a new commit to count on those lines too so you can review it.