### PR TITLE
Add deno.yaml to lint PRs

### DIFF
--- a/.github/workflows/deno-check.yaml
+++ b/.github/workflows/deno-check.yaml
@@ -17,9 +17,8 @@ jobs:
         with:
           deno-version: v2.x
 
-      # Uncomment this step to verify the use of 'deno fmt' on each commit.
-      # - name: Verify formatting
-      #   run: deno fmt --check src/**
+      - name: Verify formatting
+        run: deno fmt --check src/**
       
       - name: Run linter
         run: deno lint

--- a/.github/workflows/deno.yaml
+++ b/.github/workflows/deno.yaml
@@ -1,0 +1,25 @@
+name: Linter
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+        
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      # Uncomment this step to verify the use of 'deno fmt' on each commit.
+      # - name: Verify formatting
+      #   run: deno fmt --check src/**
+      
+      - name: Run linter
+        run: deno lint


### PR DESCRIPTION
This should help ensure that PRs are properly linted.

I tested this on my own repository here:
https://github.com/ChunkyProgrammer/invidious-companion/actions/runs/12542250314/job/34971807291?pr=1

I commented out the `deno fmt --check` step for now so it wouldn't conflict/fail for the already opened PRs