### PR TITLE
feat: timeout and retry fetches in proxy

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -16,7 +16,7 @@ directory = "/var/tmp"
 #proxy = ""
 # Enable YouTube new video format UMP
 ump = false
-# fetch_timeout = 10000
+# fetch_timeout_ms = 10000
 # fetch_retry_enable = true
 # fetch_retry_times = 3
 # fetch_retry_initial_debounce = 500

--- a/config/default.toml
+++ b/config/default.toml
@@ -16,6 +16,11 @@ directory = "/var/tmp"
 #proxy = ""
 # Enable YouTube new video format UMP
 ump = false
+# fetch_timeout = 10000
+# fetch_retry_enable = true
+# fetch_retry_times = 3
+# fetch_retry_initial_debounce = 500
+# fetch_retry_debounce_multiplier = 2
 
 [jobs]
 

--- a/src/lib/helpers/getFetchClient.ts
+++ b/src/lib/helpers/getFetchClient.ts
@@ -54,7 +54,7 @@ function fetchShim(
         "networking.fetch_retry_initial_debounce",
     );
     const fetchDebounceMultiplier = konfigStore.get(
-        "fetch_retry_debounce_multiplier",
+        "networking.fetch_retry_debounce_multiplier",
     );
     const retryOptions: RetryOptions = {
         maxAttempts: Number(fetchMaxAttempts) || 1,

--- a/src/lib/helpers/getFetchClient.ts
+++ b/src/lib/helpers/getFetchClient.ts
@@ -2,10 +2,10 @@ import { Store } from "@willsoto/node-konfig-core";
 import { retry, RetryError, type RetryOptions } from "jsr:@std/async";
 
 const retryOptions: RetryOptions = {
-  maxAttempts: 3,
-  minTimeout: 500,
-  multiplier: 2,
-  jitter: 0,
+    maxAttempts: 3,
+    minTimeout: 500,
+    multiplier: 2,
+    jitter: 0,
 };
 
 export const getFetchClient = (konfigStore: Store): {
@@ -45,9 +45,13 @@ export const getFetchClient = (konfigStore: Store): {
     return fetchShim;
 };
 
-async function fetchShim(...[input, init]: Parameters<typeof globalThis.fetch>): ReturnType<typeof globalThis.fetch> {
-  const callFetch = () => fetch(input, {
-    signal: AbortSignal.timeout(10000), ...(init || {})
-  });
-  return await retry(callFetch, retryOptions);
+async function fetchShim(
+    ...[input, init]: Parameters<typeof globalThis.fetch>
+): ReturnType<typeof globalThis.fetch> {
+    const callFetch = () =>
+        fetch(input, {
+            signal: AbortSignal.timeout(10000),
+            ...(init || {}),
+        });
+    return await retry(callFetch, retryOptions);
 }

--- a/src/lib/helpers/getFetchClient.ts
+++ b/src/lib/helpers/getFetchClient.ts
@@ -45,7 +45,7 @@ export const getFetchClient = (konfigStore: Store): {
     return fetchShim;
 };
 
-async function fetchShim(
+function fetchShim(
     ...[input, init]: Parameters<typeof globalThis.fetch>
 ): ReturnType<typeof globalThis.fetch> {
     const callFetch = () =>
@@ -53,5 +53,5 @@ async function fetchShim(
             signal: AbortSignal.timeout(10000),
             ...(init || {}),
         });
-    return await retry(callFetch, retryOptions);
+    return retry(callFetch, retryOptions);
 }

--- a/src/lib/helpers/getFetchClient.ts
+++ b/src/lib/helpers/getFetchClient.ts
@@ -46,9 +46,8 @@ function fetchShim(
     input: FetchInputParameter,
     init?: FetchInitParameterWithClient,
 ): FetchReturn {
-    const fetchTimeout = konfigStore.get("networking.fetch_timeout");
+    const fetchTimeout = konfigStore.get("networking.fetch_timeout_ms");
     const fetchRetry = konfigStore.get("networking.fetch_retry_enable");
-
     const fetchMaxAttempts = konfigStore.get("networking.fetch_retry_times");
     const fetchInitialDebounce = konfigStore.get(
         "networking.fetch_retry_initial_debounce",

--- a/src/lib/helpers/getFetchClient.ts
+++ b/src/lib/helpers/getFetchClient.ts
@@ -49,7 +49,7 @@ async function fetchShim(
     ...[input, init]: Parameters<typeof globalThis.fetch>
 ): ReturnType<typeof globalThis.fetch> {
     const callFetch = () =>
-        fetch(input, {
+        globalThis.fetch(input, {
             signal: AbortSignal.timeout(10000),
             ...(init || {}),
         });

--- a/src/lib/helpers/getFetchClient.ts
+++ b/src/lib/helpers/getFetchClient.ts
@@ -1,5 +1,5 @@
 import { Store } from "@willsoto/node-konfig-core";
-import { retry, RetryError, type RetryOptions } from "jsr:@std/async";
+import { retry, type RetryOptions } from "jsr:@std/async";
 
 const retryOptions: RetryOptions = {
     maxAttempts: 3,

--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -80,29 +80,31 @@ videoPlaybackProxy.get("/", async (c) => {
 
     const fetchClient = await getFetchClient(konfigStore);
 
-    const getGoogleVideoResponse = () => fetchClient.call(
-        undefined,
-        `https://${host}/videoplayback?${queryParams.toString()}`,
-        {
-            method: "POST",
-            body: new Uint8Array([0x78, 0]), // protobuf: { 15: 0 } (no idea what it means but this is what YouTube uses),
-            headers: headersToSend,
-            signal: AbortSignal.timeout(5000)
-        },
-    );
+    const getGoogleVideoResponse = () =>
+        fetchClient.call(
+            undefined,
+            `https://${host}/videoplayback?${queryParams.toString()}`,
+            {
+                method: "POST",
+                body: new Uint8Array([0x78, 0]), // protobuf: { 15: 0 } (no idea what it means but this is what YouTube uses),
+                headers: headersToSend,
+                signal: AbortSignal.timeout(5000),
+            },
+        );
     let googlevideoResponse = await succeedOrRetry(5, getGoogleVideoResponse);
 
     if (googlevideoResponse.headers.has("location")) {
-        const getRedirectedGoogleVideo = () => fetchClient.call(
-            undefined,
-            googlevideoResponse.headers.get("location") as string,
-            {
-                method: "POST",
-                body: new Uint8Array([0x78, 0]), // protobuf: { 15: 0 } (no idea what it means but this is what YouTube uses)
-                headers: headersToSend,
-                signal: AbortSignal.timeout(5000)
-            },
-        );
+        const getRedirectedGoogleVideo = () =>
+            fetchClient.call(
+                undefined,
+                googlevideoResponse.headers.get("location") as string,
+                {
+                    method: "POST",
+                    body: new Uint8Array([0x78, 0]), // protobuf: { 15: 0 } (no idea what it means but this is what YouTube uses)
+                    headers: headersToSend,
+                    signal: AbortSignal.timeout(5000),
+                },
+            );
         googlevideoResponse = await succeedOrRetry(5, getRedirectedGoogleVideo);
     }
 
@@ -125,7 +127,7 @@ videoPlaybackProxy.get("/", async (c) => {
 
 async function succeedOrRetry(count: number, fn: () => any) {
     if (count <= 0) {
-        throw Error('failed after retries');
+        throw Error("failed after retries");
     }
 
     try {


### PR DESCRIPTION
I made this PR to deal with an issue I was having. When using Dash on longer videos, occasionally a request to Youtube would hang. Eventually my reverse proxy would time out (about a minute) and the frontend would get a 504. It didn't retry, so the video just went to a loading animation and wouldn't work again unless the page was reloaded.

In order to resolve this, I've added a timeout to googlevideo requests, and set them to retry 5 times. So far I've had this happen 4 or 5 times in 1.5 hours of a video, and they are always succeeding on the second request. I don't have any failures with this patch.

The core of this issue may be something unreliable in my network. I'm working on resolving that, but this PR makes the companion more resilient to connections not being perfect. The alternative (or additional) way of handling this would be to make sure Invidious retries requests that come back as non-200s from the companion in Dash. Both would make sense.