### PR TITLE
Chore: Clean up Hono types

### DIFF
--- a/src/lib/types/HonoVariables.ts
+++ b/src/lib/types/HonoVariables.ts
@@ -1,5 +1,7 @@
 import { Innertube } from "youtubei.js";
+import type { konfigLoader } from "../helpers/konfigLoader.ts";
 
 export type HonoVariables = {
     innertubeClient: Innertube;
+    konfigStore: Awaited<ReturnType<typeof konfigLoader>>;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,8 +36,8 @@ if (args?.[0] == "healthcheck") {
 
 const { getFetchClient } = await import(getFetchClientLocation);
 
-declare module 'hono' {
-  interface ContextVariableMap extends HonoVariables {}
+declare module "hono" {
+    interface ContextVariableMap extends HonoVariables {}
 }
 const app = new Hono();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { routes } from "./routes/index.ts";
 import { Innertube, UniversalCache } from "youtubei.js";
 import { poTokenGenerate } from "./lib/jobs/potoken.ts";
 import { konfigLoader } from "./lib/helpers/konfigLoader.ts";
+import type { HonoVariables } from "./lib/types/HonoVariables.ts";
 let getFetchClientLocation = "getFetchClient";
 if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {
     if (Deno.env.has("DENO_COMPILED")) {
@@ -35,6 +36,9 @@ if (args?.[0] == "healthcheck") {
 
 const { getFetchClient } = await import(getFetchClientLocation);
 
+declare module 'hono' {
+  interface ContextVariableMap extends HonoVariables {}
+}
 const app = new Hono();
 
 let innertubeClient: Innertube;
@@ -124,9 +128,7 @@ if (!innertubeClientOauthEnabled) {
 }
 
 app.use("*", async (c, next) => {
-    // @ts-ignore Do not understand how to fix this error.
     c.set("innertubeClient", innertubeClient);
-    // @ts-ignore Do not understand how to fix this error.
     c.set("konfigStore", konfigStore);
     await next();
 });

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -1,7 +1,5 @@
 import { Hono } from "hono";
-import { FormatUtils, Innertube } from "youtubei.js";
-import { HonoVariables } from "../../lib/types/HonoVariables.ts";
-import { Store } from "@willsoto/node-konfig-core";
+import { FormatUtils } from "youtubei.js";
 import {
     youtubePlayerParsing,
     youtubeVideoInfo,
@@ -9,18 +7,15 @@ import {
 import { verifyRequest } from "../../lib/helpers/verifyRequest.ts";
 import { HTTPException } from "hono/http-exception";
 
-const dashManifest = new Hono<{ Variables: HonoVariables }>();
+const dashManifest = new Hono();
 
 dashManifest.get("/:videoId", async (c) => {
     const { videoId } = c.req.param();
     const { check, local } = c.req.query();
     c.header("access-control-allow-origin", "*");
 
-    const innertubeClient = await c.get("innertubeClient") as Innertube;
-    // @ts-ignore Do not understand how to fix this error.
-    const konfigStore = await c.get("konfigStore") as Store<
-        Record<string, unknown>
-    >;
+    const innertubeClient = c.get("innertubeClient");
+    const konfigStore = c.get("konfigStore");
 
     if (konfigStore.get("server.verify_requests") && check == undefined) {
         throw new HTTPException(400, {

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -1,15 +1,12 @@
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { Innertube } from "youtubei.js";
-import { HonoVariables } from "../../lib/types/HonoVariables.ts";
-import { Store } from "@willsoto/node-konfig-core";
 import {
     youtubePlayerParsing,
     youtubeVideoInfo,
 } from "../../lib/helpers/youtubePlayerHandling.ts";
 import { verifyRequest } from "../../lib/helpers/verifyRequest.ts";
 
-const latestVersion = new Hono<{ Variables: HonoVariables }>();
+const latestVersion = new Hono();
 
 latestVersion.get("/", async (c) => {
     const { check, itag, id, local } = c.req.query();
@@ -21,11 +18,8 @@ latestVersion.get("/", async (c) => {
         });
     }
 
-    const innertubeClient = await c.get("innertubeClient") as Innertube;
-    // @ts-ignore Do not understand how to fix this error.
-    const konfigStore = await c.get("konfigStore") as Store<
-        Record<string, unknown>
-    >;
+    const innertubeClient = c.get("innertubeClient");
+    const konfigStore = await c.get("konfigStore");
 
     if (konfigStore.get("server.verify_requests") && check == undefined) {
         throw new HTTPException(400, {

--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { Store } from "@willsoto/node-konfig-core";
 import { HTTPException } from "hono/http-exception";
 let getFetchClientLocation = "getFetchClient";
 if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {
@@ -44,10 +43,7 @@ videoPlaybackProxy.get("/", async (c) => {
         });
     }
 
-    // @ts-ignore Do not understand how to fix this error.
-    const konfigStore = await c.get("konfigStore") as Store<
-        Record<string, unknown>
-    >;
+    const konfigStore = c.get("konfigStore");
 
     // deno-lint-ignore prefer-const
     let queryParams = new URLSearchParams(urlReq.search);

--- a/src/routes/youtube_api_routes/player.ts
+++ b/src/routes/youtube_api_routes/player.ts
@@ -1,18 +1,12 @@
 import { Hono } from "hono";
 import { youtubePlayerParsing } from "../../lib/helpers/youtubePlayerHandling.ts";
-import { HonoVariables } from "../../lib/types/HonoVariables.ts";
-import { Innertube } from "youtubei.js";
-import { Store } from "@willsoto/node-konfig-core";
 
-const player = new Hono<{ Variables: HonoVariables }>();
+const player = new Hono();
 
 player.post("/player", async (c) => {
     const jsonReq = await c.req.json();
-    const innertubeClient = await c.get("innertubeClient") as Innertube;
-    // @ts-ignore Do not understand how to fix this error.
-    const konfigStore = await c.get("konfigStore") as Store<
-        Record<string, unknown>
-    >;
+    const innertubeClient = c.get("innertubeClient");
+    const konfigStore = c.get("konfigStore");
     if (jsonReq.videoId) {
         return c.json(
             await youtubePlayerParsing(


### PR DESCRIPTION
Hono context variables can be typed by setting ContextVariableMap in the 'hono' module. This allows the type-checks to be cleaner and simpler, and to not require ts overrides

c.get also isn't async, so doesn't need to be awaited