### PR TITLE
dockerfile: replace built-in healthcheck with tiny-health-checker for container healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,3 @@ WORKDIR /app
 USER appuser
 
 ENTRYPOINT ["/tini", "--", "/app/invidious_companion"]
-
-HEALTHCHECK --interval=5s --timeout=5s --start-period=10s --retries=3 CMD ["/tini", "--", "/app/invidious_companion", "healthcheck"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION
         --output /tini \
     && chmod +x /tini
 
+RUN curl -fsSL https://github.com/dmikusa/tiny-health-checker/releases/download/v0.33.0/thc-x86_64-unknown-linux-musl \
+    --output /thc \
+&& chmod +x /thc
+
 RUN deno task compile
 
 # Stage for creating the non-privileged user
@@ -26,11 +30,15 @@ RUN adduser -u 10001 -S appuser
 FROM gcr.io/distroless/cc
 
 COPY --from=builder /app/invidious_companion /app/
+COPY --from=builder /thc /thc
 COPY ./config/ /app/config/
 COPY --from=builder /tini /tini
 
 ENV PORT=8282 \
     HOST=0.0.0.0
+
+ENV THC_PORT=${PORT} \
+    THC_PATH=/healthz
 
 # Copy passwd file for the non-privileged user from the user-stage
 COPY --from=user-stage /etc/passwd /etc/passwd
@@ -45,3 +53,5 @@ WORKDIR /app
 USER appuser
 
 ENTRYPOINT ["/tini", "--", "/app/invidious_companion"]
+
+HEALTHCHECK --interval=5s --timeout=5s --start-period=10s --retries=5 CMD ["/thc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,10 @@ RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION
         --output /tini \
     && chmod +x /tini
 
-RUN curl -fsSL https://github.com/dmikusa/tiny-health-checker/releases/download/v0.33.0/thc-x86_64-unknown-linux-musl \
+RUN arch=$(uname -m) && \
+    curl -fsSL https://github.com/dmikusa/tiny-health-checker/releases/download/v0.36.0/thc-${arch}-unknown-linux-musl \
     --output /thc \
-&& chmod +x /thc
+    && chmod +x /thc
 
 RUN deno task compile
 


### PR DESCRIPTION
Replaces https://github.com/iv-org/invidious-companion/pull/48 due to https://github.com/iv-org/invidious-companion/issues/24#issuecomment-2677141666