### PR TITLE
fix: Replace c.text by c.body to prevent Content-Type header being rewriten

### DIFF
--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -102,7 +102,7 @@ dashManifest.get("/:videoId", async (c) => {
             captions,
             undefined,
         );
-        return c.text(dashFile.replaceAll("&amp;", "&"));
+        return c.body(dashFile.replaceAll("&amp;", "&"));
     }
 });
 


### PR DESCRIPTION
`c.text` sets the Content-Type to `text/plain; charset=UTF-8` regardless of the value set by `c.header()`. Using c.body prevents that from happening.