### PR TITLE
chore: remove base_url sending

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -3,7 +3,6 @@ port = 8282
 host = "127.0.0.1"
 # secret key needs to be 16 characters long or more
 secret_key = "CHANGE_ME"
-base_url = "http://localhost:8282"
 verify_requests = false
 
 [cache]

--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -133,10 +133,6 @@ export const youtubePlayerParsing = async (
             streamingData,
             videoDetails,
             microformat,
-            invidiousCompanion: {
-                "baseUrl": Deno.env.get("SERVER_BASE_URL") ||
-                    konfigStore.get("server.base_url") as string,
-            },
         }))(videoData);
 
         if (


### PR DESCRIPTION
Remove the usage of base_url in companion since like @Fijxu said, invidious has this info now through "public_url": https://github.com/iv-org/invidious/pull/4985#issuecomment-2692940672