### PR TITLE
fix: remove replaceAll("&amp;", "&") from dash manifest

### DIFF
--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -102,7 +102,7 @@ dashManifest.get("/:videoId", async (c) => {
             captions,
             undefined,
         );
-        return c.body(dashFile.replaceAll("&amp;", "&"));
+        return c.body(dashFile);
     }
 });
 


### PR DESCRIPTION
At the moment, the manifest XML returned from companion is invalid XML:

![image](https://github.com/user-attachments/assets/6e27d659-7cb9-4c26-aaaf-3775d76a8139)

vs (with the change included here)

![image](https://github.com/user-attachments/assets/27621ee4-51df-4b08-a4cb-45aca1219e5f)

This change fixes the issue with Clipious not working - https://github.com/iv-org/invidious-companion/issues/22 - though I'm not sure about the other players. The error in Clipious is an XML parsing error:

![image](https://github.com/user-attachments/assets/376950b3-e8d0-4ea0-8195-b940b51c1c75)

and goes away after this fix - videos play just fine on a companion-enabled instance after this.


If we can see if this change negatively impacts any other parts, hopefully we can fix those at the source.  