### PR TITLE
feat: add support for encrypted query parameters

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -15,6 +15,7 @@
 # # secret key needs to be 16 characters long or more
 # secret_key = "CHANGE_ME" # env variable: SERVER_SECRET_KEY
 # verify_requests = false
+# encrypt_query_params = false # env variable: ENCRYPT_QUERY_PARAMS
  
 # [cache]
 # enabled = true

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -15,7 +15,7 @@
 # # secret key needs to be 16 characters long or more
 # secret_key = "CHANGE_ME" # env variable: SERVER_SECRET_KEY
 # verify_requests = false
-# encrypt_query_params = false # env variable: ENCRYPT_QUERY_PARAMS
+# encrypt_query_params = false # env variable: SERVER_ENCRYPT_QUERY_PARAMS
  
 # [cache]
 # enabled = true

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -9,6 +9,9 @@ const ConfigSchema = z.object({
             Deno.env.get("SERVER_SECRET_KEY") || "",
         ),
         verify_requests: z.boolean().default(false),
+        encrypt_query_params: z.boolean().default(
+            Deno.env.get("ENCRYPT_QUERY_PARAMS") === "true" || false,
+        ),
     }).strict().default({}),
     cache: z.object({
         enabled: z.boolean().default(true),

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -10,7 +10,7 @@ const ConfigSchema = z.object({
         ),
         verify_requests: z.boolean().default(false),
         encrypt_query_params: z.boolean().default(
-            Deno.env.get("ENCRYPT_QUERY_PARAMS") === "true" || false,
+            Deno.env.get("SERVER_ENCRYPT_QUERY_PARAMS") === "true" || false,
         ),
     }).strict().default({}),
     cache: z.object({

--- a/src/lib/helpers/encryptQuery.ts
+++ b/src/lib/helpers/encryptQuery.ts
@@ -22,7 +22,7 @@ export const encryptQuery = (
 
         const encryptedData = cipher.encrypt(encodedData);
 
-        return encodeBase64(encryptedData)
+        return encodeBase64(encryptedData);
     } catch (err) {
         console.error("[ERROR] Failed to encrypt query parameters:", err);
         return "";

--- a/src/lib/helpers/encryptQuery.ts
+++ b/src/lib/helpers/encryptQuery.ts
@@ -1,0 +1,59 @@
+import { decodeBase64, encodeBase64 } from "@std/encoding/base64";
+import { Aes } from "crypto/aes.ts";
+import { Ecb, Padding } from "crypto/block-modes.ts";
+import type { Config } from "./config.ts";
+
+export const encryptQuery = (
+    queryParams: string,
+    config: Config,
+): string => {
+    try {
+        const cipher = new Ecb(
+            Aes,
+            new TextEncoder().encode(
+                config.server.secret_key,
+            ),
+            Padding.PKCS7,
+        );
+
+        const encodedData = new TextEncoder().encode(
+            queryParams,
+        );
+
+        const encryptedData = cipher.encrypt(encodedData);
+
+        return encodeBase64(encryptedData).replace(/\+/g, "-").replace(
+            /\//g,
+            "_",
+        );
+    } catch (err) {
+        console.error("[ERROR] Failed to encrypt query parameters:", err);
+        return "";
+    }
+};
+
+export const decryptQuery = (
+    queryParams: string,
+    config: Config,
+): string => {
+    try {
+        const decipher = new Ecb(
+            Aes,
+            new TextEncoder().encode(config.server.secret_key),
+            Padding.PKCS7,
+        );
+
+        const decryptedData = new TextDecoder().decode(
+            decipher.decrypt(
+                decodeBase64(
+                    queryParams.replace(/-/g, "+").replace(/_/g, "/"),
+                ),
+            ),
+        );
+
+        return decryptedData;
+    } catch (err) {
+        console.error("[ERROR] Failed to decrypt query parameters:", err);
+        return "";
+    }
+};

--- a/src/lib/helpers/encryptQuery.ts
+++ b/src/lib/helpers/encryptQuery.ts
@@ -22,10 +22,7 @@ export const encryptQuery = (
 
         const encryptedData = cipher.encrypt(encodedData);
 
-        return encodeBase64(encryptedData).replace(/\+/g, "-").replace(
-            /\//g,
-            "_",
-        );
+        return encodeBase64(encryptedData)
     } catch (err) {
         console.error("[ERROR] Failed to encrypt query parameters:", err);
         return "";
@@ -46,7 +43,7 @@ export const decryptQuery = (
         const decryptedData = new TextDecoder().decode(
             decipher.decrypt(
                 decodeBase64(
-                    queryParams.replace(/-/g, "+").replace(/_/g, "/"),
+                    queryParams,
                 ),
             ),
         );

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -85,6 +85,7 @@ dashManifest.get("/:videoId", async (c) => {
             (url: URL) => {
                 let dashUrl = url;
                 let queryParams = new URLSearchParams(dashUrl.search);
+                // Can't create URL type without host part
                 queryParams.set("host", dashUrl.host);
 
                 if (local) {

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -109,15 +109,9 @@ dashManifest.get("/:videoId", async (c) => {
                                 config,
                             );
                     }
-                    dashUrl = (
-                        Deno.env.get("EXTERNAL_VIDEOPLAYBACK_PROXY") ||
-                        (konfigStore.get(
-                            "networking.external_videoplayback_proxy",
-                        ) as string ?? "")
-                    ) +
-                        (dashUrl.pathname + "?" +
-                            queryParams.toString() +
-                            encryptedParams) as unknown as URL;
+                    dashUrl = (dashUrl.pathname + "?" +
+                        queryParams.toString() +
+                        encryptedParams) as unknown as URL;
                     return dashUrl;
                 } else {
                     return dashUrl;

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -84,12 +84,8 @@ dashManifest.get("/:videoId", async (c) => {
             videoInfo.page[0].video_details?.is_post_live_dvr,
             (url: URL) => {
                 let dashUrl = url;
-                // Can't create URL type without host part
-                const queryParams = new URLSearchParams(
-                    dashUrl.search.substring(1) + "&host=" +
-                        dashUrl.host,
-                );
-                let encryptedParams: string = "";
+                const queryParams = new URLSearchParams(dashUrl.search);
+                queryParams.set("host", dashUrl.host);
 
                 if (local) {
                     if (config.networking.ump) {
@@ -99,19 +95,19 @@ dashManifest.get("/:videoId", async (c) => {
                         config.server.encrypt_query_params
                     ) {
                         const privateParams = "&pot=" +
-                            dashUrl.searchParams.get("pot") +
-                            "&ip=" + dashUrl.searchParams.get("ip");
+                            queryParams.get("pot") +
+                            "&ip=" + queryParams.get("ip");
+                        const encryptedParams = encryptQuery(
+                            privateParams,
+                            config,
+                        );
                         queryParams.delete("pot");
                         queryParams.delete("ip");
-                        encryptedParams = "&enc=yes&data=" +
-                            encryptQuery(
-                                privateParams,
-                                config,
-                            );
+                        queryParams.set("enc", "true");
+                        queryParams.set("data", encryptedParams);
                     }
                     dashUrl = (dashUrl.pathname + "?" +
-                        queryParams.toString() +
-                        encryptedParams) as unknown as URL;
+                        queryParams.toString()) as unknown as URL;
                     return dashUrl;
                 } else {
                     return dashUrl;

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -84,7 +84,7 @@ dashManifest.get("/:videoId", async (c) => {
             videoInfo.page[0].video_details?.is_post_live_dvr,
             (url: URL) => {
                 let dashUrl = url;
-                const queryParams = new URLSearchParams(dashUrl.search);
+                let queryParams = new URLSearchParams(dashUrl.search);
                 queryParams.set("host", dashUrl.host);
 
                 if (local) {
@@ -94,15 +94,17 @@ dashManifest.get("/:videoId", async (c) => {
                     if (
                         config.server.encrypt_query_params
                     ) {
-                        const privateParams = "&pot=" +
-                            queryParams.get("pot") +
-                            "&ip=" + queryParams.get("ip");
+                        const publicParams = [...queryParams].filter(([key]) =>
+                            ["pot", "ip"].includes(key) === false
+                        );
+                        const privateParams = [...queryParams].filter(([key]) =>
+                            ["pot", "ip"].includes(key) === true
+                        );
                         const encryptedParams = encryptQuery(
-                            privateParams,
+                            JSON.stringify(privateParams),
                             config,
                         );
-                        queryParams.delete("pot");
-                        queryParams.delete("ip");
+                        queryParams = new URLSearchParams(publicParams);
                         queryParams.set("enc", "true");
                         queryParams.set("data", encryptedParams);
                     }

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -83,14 +83,9 @@ latestVersion.get("/", async (c) => {
                         config,
                     );
             }
-            urlToRedirect = (
-                Deno.env.get("EXTERNAL_VIDEOPLAYBACK_PROXY") ||
-                (konfigStore.get(
-                    "networking.external_videoplayback_proxy",
-                ) as string ?? "")
-            ) +
-                (itagUrlParsed.pathname + "?" + queryParams.toString() +
-                    encryptedParams) as string;
+            urlToRedirect = itagUrlParsed.pathname + "?" +
+                queryParams.toString() +
+                encryptedParams;
         }
 
         if (title) urlToRedirect += `&title=${encodeURIComponent(title)}`;

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -63,29 +63,26 @@ latestVersion.get("/", async (c) => {
     } else if (selectedItagFormat) {
         const itagUrl = selectedItagFormat[0].url as string;
         const itagUrlParsed = new URL(itagUrl);
+        const queryParams = new URLSearchParams(itagUrlParsed.search);
         let urlToRedirect = itagUrlParsed.toString();
-        const queryParams = new URLSearchParams(
-            itagUrlParsed.search.substring(1) + "&host=" +
-                itagUrlParsed.host,
-        );
-        let encryptedParams: string = "";
 
         if (local) {
+            queryParams.set("host", itagUrlParsed.host);
             if (config.server.encrypt_query_params) {
                 const privateParams = "&pot=" +
-                    itagUrlParsed.searchParams.get("pot") + "&ip=" +
-                    itagUrlParsed.searchParams.get("ip");
+                    queryParams.get("pot") +
+                    "&ip=" + queryParams.get("ip");
+                const encryptedParams = encryptQuery(
+                    privateParams,
+                    config,
+                );
                 queryParams.delete("pot");
                 queryParams.delete("ip");
-                encryptedParams = "&enc=yes&data=" +
-                    encryptQuery(
-                        privateParams,
-                        config,
-                    );
+                queryParams.set("enc", "true");
+                queryParams.set("data", encryptedParams);
             }
             urlToRedirect = itagUrlParsed.pathname + "?" +
-                queryParams.toString() +
-                encryptedParams;
+                queryParams.toString();
         }
 
         if (title) urlToRedirect += `&title=${encodeURIComponent(title)}`;

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -63,21 +63,23 @@ latestVersion.get("/", async (c) => {
     } else if (selectedItagFormat) {
         const itagUrl = selectedItagFormat[0].url as string;
         const itagUrlParsed = new URL(itagUrl);
-        const queryParams = new URLSearchParams(itagUrlParsed.search);
+        let queryParams = new URLSearchParams(itagUrlParsed.search);
         let urlToRedirect = itagUrlParsed.toString();
 
         if (local) {
             queryParams.set("host", itagUrlParsed.host);
             if (config.server.encrypt_query_params) {
-                const privateParams = "&pot=" +
-                    queryParams.get("pot") +
-                    "&ip=" + queryParams.get("ip");
+                const publicParams = [...queryParams].filter(([key]) =>
+                    ["pot", "ip"].includes(key) === false
+                );
+                const privateParams = [...queryParams].filter(([key]) =>
+                    ["pot", "ip"].includes(key) === true
+                );
                 const encryptedParams = encryptQuery(
-                    privateParams,
+                    JSON.stringify(privateParams),
                     config,
                 );
-                queryParams.delete("pot");
-                queryParams.delete("ip");
+                queryParams = new URLSearchParams(publicParams);
                 queryParams.set("enc", "true");
                 queryParams.set("data", encryptedParams);
             }

--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -24,13 +24,13 @@ videoPlaybackProxy.get("/", async (c) => {
     const urlReq = new URL(c.req.url);
     const queryParams = new URLSearchParams(urlReq.search);
 
-    if (c.req.query("enc") === "yes") {
+    if (c.req.query("enc") === "true") {
         const { data: encryptedQuery } = c.req.query();
-        const unencryptedQueryParams = new URLSearchParams(decryptQuery(
-            encryptedQuery,
-            config,
-        ));
-        unencryptedQueryParams.forEach((k, v) => {
+        const decryptedQueryParams = decryptQuery(encryptedQuery, config);
+        const parsedDecryptedQueryParams = new URLSearchParams(
+            decryptedQueryParams,
+        );
+        parsedDecryptedQueryParams.forEach((k, v) => {
             queryParams.set(v, k);
         });
         queryParams.delete("enc");
@@ -59,7 +59,6 @@ videoPlaybackProxy.get("/", async (c) => {
             res: new Response("'c' query string undefined."),
         });
     }
-
 
     queryParams.delete("host");
     queryParams.delete("title");

--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -19,22 +19,21 @@ const { getFetchClient } = await import(getFetchClientLocation);
 const videoPlaybackProxy = new Hono();
 
 videoPlaybackProxy.get("/", async (c) => {
-    const config = c.get("config");
-    const { host, c: client, expire } = c.req.query();
+    const { host, c: client, expire, title } = c.req.query();
     const urlReq = new URL(c.req.url);
+    const config = c.get("config");
     const queryParams = new URLSearchParams(urlReq.search);
 
     if (c.req.query("enc") === "true") {
         const { data: encryptedQuery } = c.req.query();
         const decryptedQueryParams = decryptQuery(encryptedQuery, config);
         const parsedDecryptedQueryParams = new URLSearchParams(
-            decryptedQueryParams,
+            JSON.parse(decryptedQueryParams),
         );
-        parsedDecryptedQueryParams.forEach((k, v) => {
-            queryParams.set(v, k);
-        });
         queryParams.delete("enc");
         queryParams.delete("data");
+        queryParams.set("pot", parsedDecryptedQueryParams.get("pot") as string);
+        queryParams.set("ip", parsedDecryptedQueryParams.get("ip") as string);
     }
 
     if (host == undefined || !/[\w-]+.googlevideo.com/.test(host)) {


### PR DESCRIPTION
Closes #29

Requires support in Invidious if videoplayback is going to be proxied trough Invidious, but that doesn't make that much sense since companion already does that. Same thing applies to [piped-proxy](https://github.com/TeamPiped/piped-proxy)