### PR TITLE
chore: check length minimum 16

### DIFF
--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -5,7 +5,7 @@ const ConfigSchema = z.object({
     server: z.object({
         port: z.number().default(Number(Deno.env.get("PORT")) || 8282),
         host: z.string().default(Deno.env.get("HOST") || "127.0.0.1"),
-        secret_key: z.string().length(16).default(
+        secret_key: z.string().min(16).default(
             Deno.env.get("SERVER_SECRET_KEY") || "",
         ),
         verify_requests: z.boolean().default(false),


### PR DESCRIPTION
Changing from strict 16 characters only to minimum 16 characters.

The lib that we use just cut after 16 characters, so we can allow people to set more than 16 characters if they really want. And on the invidious side, we only check if it's more than 16 characters:
https://github.com/iv-org/invidious/blob/409d12a81e75451a8efc7574d4bad622f75d3769/src/invidious/config.cr#L270-L272