### PR TITLE
Move po token to webworker

### DIFF
--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -1,7 +1,7 @@
 import { z, ZodError } from "zod";
 import { parse } from "@std/toml";
 
-const ConfigSchema = z.object({
+export const ConfigSchema = z.object({
     server: z.object({
         port: z.number().default(Number(Deno.env.get("PORT")) || 8282),
         host: z.string().default(Deno.env.get("HOST") || "127.0.0.1"),

--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -1,7 +1,7 @@
 import { ApiResponse, Innertube, YT } from "youtubei.js";
 import { generateRandomString } from "youtubei.js/Utils";
 import { compress, decompress } from "brotli";
-import type { BG } from "bgutils";
+import type { TokenMinter } from "../jobs/potoken.ts";
 let youtubePlayerReqLocation = "youtubePlayerReq";
 if (Deno.env.get("YT_PLAYER_REQ_LOCATION")) {
     if (Deno.env.has("DENO_COMPILED")) {
@@ -29,7 +29,7 @@ export const youtubePlayerParsing = async ({
     innertubeClient: Innertube;
     videoId: string;
     config: Config;
-    tokenMinter: BG.WebPoMinter;
+    tokenMinter: TokenMinter;
     overrideCache?: boolean;
 }): Promise<object> => {
     const cacheEnabled = overrideCache ? false : config.cache.enabled;

--- a/src/lib/helpers/youtubePlayerReq.ts
+++ b/src/lib/helpers/youtubePlayerReq.ts
@@ -1,6 +1,6 @@
 import { ApiResponse, Innertube } from "youtubei.js";
 import NavigationEndpoint from "youtubei.js/NavigationEndpoint";
-import type { BG } from "bgutils";
+import type { TokenMinter } from "../jobs/potoken.ts";
 
 import type { Config } from "./config.ts";
 
@@ -8,7 +8,7 @@ export const youtubePlayerReq = async (
     innertubeClient: Innertube,
     videoId: string,
     config: Config,
-    tokenMinter: BG.WebPoMinter,
+    tokenMinter: TokenMinter,
 ): Promise<ApiResponse> => {
     const innertubeClientOauthEnabled = config.youtube_session.oauth_enabled;
 
@@ -21,7 +21,7 @@ export const youtubePlayerReq = async (
         watchEndpoint: { videoId: videoId },
     });
 
-    const contentPoToken = await tokenMinter.mintAsWebsafeString(videoId);
+    const contentPoToken = await tokenMinter(videoId);
 
     return watch_endpoint.call(innertubeClient.actions, {
         playbackContext: {

--- a/src/lib/jobs/potoken.ts
+++ b/src/lib/jobs/potoken.ts
@@ -1,4 +1,4 @@
-import { Innertube, UniversalCache } from "youtubei.js";
+import { Innertube } from "youtubei.js";
 import {
     youtubePlayerParsing,
     youtubeVideoInfo,

--- a/src/lib/jobs/potoken.ts
+++ b/src/lib/jobs/potoken.ts
@@ -84,6 +84,7 @@ export const poTokenGenerate = (
         }
 
         if (parsedMessage.type === "error") {
+            console.log({ errorFromWorker: parsedMessage.error });
             worker.terminate();
             reject(parsedMessage.error);
         }

--- a/src/lib/jobs/potoken.ts
+++ b/src/lib/jobs/potoken.ts
@@ -1,7 +1,4 @@
-import { BG, buildURL, GOOG_API_KEY, USER_AGENT } from "bgutils";
-import type { WebPoSignalOutput } from "bgutils";
-import { JSDOM } from "jsdom";
-import { Innertube } from "youtubei.js";
+import { Innertube, UniversalCache } from "youtubei.js";
 import {
     youtubePlayerParsing,
     youtubeVideoInfo,
@@ -20,118 +17,129 @@ if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {
 }
 const { getFetchClient } = await import(getFetchClientLocation);
 
+import { InputMessage, OutputMessageSchema } from "./worker.ts";
+
+interface TokenGeneratorWorker extends Omit<Worker, "postMessage"> {
+    postMessage(message: InputMessage): void;
+}
+
+const workers: TokenGeneratorWorker[] = [];
+
+function createMinter(worker: TokenGeneratorWorker) {
+    return (videoId: string): Promise<string> => {
+        const { promise, resolve } = Promise.withResolvers<string>();
+        // generate a UUID to identify the request as many minter calls
+        // may be made within a timespan, and this function will be
+        // informed about all of them until it's got its own
+        const requestId = crypto.randomUUID();
+        const listener = (message: MessageEvent) => {
+            const parsedMessage = OutputMessageSchema.parse(message.data);
+            if (
+                parsedMessage.type === "content-token" &&
+                parsedMessage.requestId === requestId
+            ) {
+                worker.removeEventListener("message", listener);
+                resolve(parsedMessage.contentToken);
+            }
+        };
+        worker.addEventListener("message", listener);
+        worker.postMessage({
+            type: "content-token-request",
+            videoId,
+            requestId,
+        });
+
+        return promise;
+    };
+}
+
+export type TokenMinter = ReturnType<typeof createMinter>;
+
 // Adapted from https://github.com/LuanRT/BgUtils/blob/main/examples/node/index.ts
-export const poTokenGenerate = async (
-    innertubeClient: Innertube,
+export const poTokenGenerate = (
     config: Config,
-): Promise<{ innertubeClient: Innertube; tokenMinter: BG.WebPoMinter }> => {
-    if (innertubeClient.session.po_token) {
-        innertubeClient = await Innertube.create({
-            enable_session_cache: false,
-            user_agent: USER_AGENT,
-            retrieve_player: false,
-        });
-    }
+): Promise<{ innertubeClient: Innertube; tokenMinter: TokenMinter }> => {
+    const { promise, resolve, reject } = Promise.withResolvers<
+        Awaited<ReturnType<typeof poTokenGenerate>>
+    >();
 
-    const fetchImpl = await getFetchClient(config);
-
-    const visitorData = innertubeClient.session.context.client.visitorData;
-
-    if (!visitorData) {
-        throw new Error("Could not get visitor data");
-    }
-
-    const dom = new JSDOM(
-        '<!DOCTYPE html><html lang="en"><head><title></title></head><body></body></html>',
+    const worker: TokenGeneratorWorker = new Worker(
+        new URL("./worker.ts", import.meta.url).href,
         {
-            url: "https://www.youtube.com/",
-            referrer: "https://www.youtube.com/",
-            userAgent: USER_AGENT,
+            type: "module",
+            name: "PO Token Generator",
         },
     );
+    // take note of the worker so we can kill it once a new one takes its place
+    workers.push(worker);
+    worker.addEventListener("message", async (event) => {
+        const parsedMessage = OutputMessageSchema.parse(event.data);
 
-    Object.assign(globalThis, {
-        window: dom.window,
-        document: dom.window.document,
-        location: dom.window.location,
-        origin: dom.window.origin,
+        // worker is listening for messages
+        if (parsedMessage.type === "ready") {
+            const untypedPostMessage = worker.postMessage.bind(worker);
+            worker.postMessage = (message: InputMessage) =>
+                untypedPostMessage(message);
+            worker.postMessage({ type: "initialise", config });
+        }
+
+        if (parsedMessage.type === "error") {
+            worker.terminate();
+            reject(parsedMessage.error);
+        }
+
+        // worker is initialised and has passed back a session token and visitor data
+        if (parsedMessage.type === "initialised") {
+            try {
+                const instantiatedInnertubeClient = await Innertube.create({
+                    enable_session_cache: false,
+                    po_token: parsedMessage.sessionPoToken,
+                    visitor_data: parsedMessage.visitorData,
+                    fetch: getFetchClient(config),
+                    generate_session_locally: true,
+                });
+                const minter = createMinter(worker);
+                // check token from minter
+                await checkToken({
+                    instantiatedInnertubeClient,
+                    config,
+                    integrityTokenBasedMinter: minter,
+                });
+                console.log("Successfully generated PO token");
+                const numberToKill = workers.length - 1;
+                for (let i = 0; i < numberToKill; i++) {
+                    const workerToKill = workers.shift();
+                    console.log("KILLING:", { workerToKill });
+                    workerToKill?.terminate();
+                }
+                console.log("Remaining workers", workers);
+                return resolve({
+                    innertubeClient: instantiatedInnertubeClient,
+                    tokenMinter: minter,
+                });
+            } catch (err) {
+                console.log("Failed to get valid PO token, will retry", {
+                    err,
+                });
+                worker.terminate();
+                reject(err);
+            }
+        }
     });
 
-    if (!Reflect.has(globalThis, "navigator")) {
-        Object.defineProperty(globalThis, "navigator", {
-            value: dom.window.navigator,
-        });
-    }
+    return promise;
+};
 
-    const challengeResponse = await innertubeClient.getAttestationChallenge(
-        "ENGAGEMENT_TYPE_UNBOUND",
-    );
-    if (!challengeResponse.bg_challenge) {
-        throw new Error("Could not get challenge");
-    }
-
-    const interpreterUrl = challengeResponse.bg_challenge.interpreter_url
-        .private_do_not_access_or_else_trusted_resource_url_wrapped_value;
-    const bgScriptResponse = await fetchImpl(
-        `http:${interpreterUrl}`,
-    );
-    const interpreterJavascript = await bgScriptResponse.text();
-
-    if (interpreterJavascript) {
-        new Function(interpreterJavascript)();
-    } else throw new Error("Could not load VM");
-
-    // Botguard currently surfaces a "Not implemented" error here, due to the environment
-    // not having a valid Canvas API in JSDOM. At the time of writing, this doesn't cause
-    // any issues as the Canvas check doesn't appear to be an enforced element of the checks
-    console.log(
-        '[INFO] the "Not implemented: HTMLCanvasElement.prototype.getContext" error is normal. Please do not open a bug report about it.',
-    );
-    const botguard = await BG.BotGuardClient.create({
-        program: challengeResponse.bg_challenge.program,
-        globalName: challengeResponse.bg_challenge.global_name,
-        globalObj: globalThis,
-    });
-
-    const webPoSignalOutput: WebPoSignalOutput = [];
-    const botguardResponse = await botguard.snapshot({ webPoSignalOutput });
-    const requestKey = "O43z0dpjhgX20SCx4KAo";
-
-    const integrityTokenResponse = await fetchImpl(
-        buildURL("GenerateIT", true),
-        {
-            method: "POST",
-            headers: {
-                "content-type": "application/json+protobuf",
-                "x-goog-api-key": GOOG_API_KEY,
-                "x-user-agent": "grpc-web-javascript/0.1",
-                "user-agent": USER_AGENT,
-            },
-            body: JSON.stringify([requestKey, botguardResponse]),
-        },
-    );
-
-    const response = await integrityTokenResponse.json() as unknown[];
-
-    if (typeof response[0] !== "string") {
-        throw new Error("Could not get integrity token");
-    }
-
-    const integrityTokenBasedMinter = await BG.WebPoMinter.create({
-        integrityToken: response[0],
-    }, webPoSignalOutput);
-
-    const sessionPoToken = await integrityTokenBasedMinter.mintAsWebsafeString(
-        visitorData,
-    );
-
-    const instantiatedInnertubeClient = await Innertube.create({
-        enable_session_cache: false,
-        po_token: sessionPoToken,
-        visitor_data: visitorData,
-        fetch: getFetchClient(config),
-        generate_session_locally: true,
-    });
+async function checkToken({
+    instantiatedInnertubeClient,
+    config,
+    integrityTokenBasedMinter,
+}: {
+    instantiatedInnertubeClient: Innertube;
+    config: Config;
+    integrityTokenBasedMinter: TokenMinter;
+}) {
+    const fetchImpl = getFetchClient(config);
 
     try {
         const feed = await instantiatedInnertubeClient.getTrending();
@@ -174,9 +182,4 @@ export const poTokenGenerate = async (
         console.log("Failed to get valid PO token, will retry", { err });
         throw err;
     }
-
-    return {
-        innertubeClient: instantiatedInnertubeClient,
-        tokenMinter: integrityTokenBasedMinter,
-    };
-};
+}

--- a/src/lib/jobs/potoken.ts
+++ b/src/lib/jobs/potoken.ts
@@ -110,10 +110,8 @@ export const poTokenGenerate = (
                 const numberToKill = workers.length - 1;
                 for (let i = 0; i < numberToKill; i++) {
                     const workerToKill = workers.shift();
-                    console.log("KILLING:", { workerToKill });
                     workerToKill?.terminate();
                 }
-                console.log("Remaining workers", workers);
                 return resolve({
                     innertubeClient: instantiatedInnertubeClient,
                     tokenMinter: minter,

--- a/src/lib/jobs/worker.ts
+++ b/src/lib/jobs/worker.ts
@@ -32,7 +32,10 @@ const InputContentTokenSchema = z.object({
 }).strict();
 export type InputInitialise = z.infer<typeof InputInitialiseSchema>;
 export type InputContentToken = z.infer<typeof InputContentTokenSchema>;
-const InputMessageSchema = InputInitialiseSchema.or(InputContentTokenSchema);
+const InputMessageSchema = z.union([
+    InputInitialiseSchema,
+    InputContentTokenSchema
+]);
 export type InputMessage = z.infer<typeof InputMessageSchema>;
 
 // ---- Messages that the webworker sends to the parent ----
@@ -56,8 +59,12 @@ const OutputErrorSchema = z.object({
     type: z.literal("error"),
     error: z.any(),
 }).strict();
-export const OutputMessageSchema = OutputReadySchema.or(OutputInitialiseSchema)
-    .or(OutputContentTokenSchema).or(OutputErrorSchema);
+export const OutputMessageSchema = z.union([
+    OutputReadySchema,
+    OutputInitialiseSchema,
+    OutputContentTokenSchema,
+    OutputErrorSchema,
+]);
 type OutputMessage = z.infer<typeof OutputMessageSchema>;
 
 const isWorker = typeof WorkerGlobalScope !== "undefined" &&

--- a/src/lib/jobs/worker.ts
+++ b/src/lib/jobs/worker.ts
@@ -34,7 +34,7 @@ export type InputInitialise = z.infer<typeof InputInitialiseSchema>;
 export type InputContentToken = z.infer<typeof InputContentTokenSchema>;
 const InputMessageSchema = z.union([
     InputInitialiseSchema,
-    InputContentTokenSchema
+    InputContentTokenSchema,
 ]);
 export type InputMessage = z.infer<typeof InputMessageSchema>;
 

--- a/src/lib/jobs/worker.ts
+++ b/src/lib/jobs/worker.ts
@@ -125,25 +125,6 @@ if (isWorker) {
     };
 
     postMessage({ type: "ready" });
-
-    setInterval(() => {
-        Deno.memoryUsage();
-        console.log(`[WORKER] \
-heapUsed: ${
-            (Deno.memoryUsage().heapUsed / 1_000_000).toFixed(0).toString()
-                .padStart(4, " ")
-        }MB, \
-external: ${
-            (Deno.memoryUsage().external / 1_000_000).toFixed(0).toString()
-                .padStart(4, " ")
-        }MB, \
-rss: ${
-            (Deno.memoryUsage().rss / 1_000_000).toFixed(0).toString().padStart(
-                4,
-                " ",
-            )
-        }MB`);
-    }, 1_000);
 }
 
 async function setup(

--- a/src/lib/jobs/worker.ts
+++ b/src/lib/jobs/worker.ts
@@ -110,6 +110,25 @@ if (isWorker) {
     };
 
     postMessage({ type: "ready" });
+
+    setInterval(() => {
+        Deno.memoryUsage();
+        console.log(`[WORKER] \
+heapUsed: ${
+            (Deno.memoryUsage().heapUsed / 1_000_000).toFixed(0).toString()
+                .padStart(4, " ")
+        }MB, \
+external: ${
+            (Deno.memoryUsage().external / 1_000_000).toFixed(0).toString()
+                .padStart(4, " ")
+        }MB, \
+rss: ${
+            (Deno.memoryUsage().rss / 1_000_000).toFixed(0).toString().padStart(
+                4,
+                " ",
+            )
+        }MB`);
+    }, 1_000);
 }
 
 async function setup(

--- a/src/lib/jobs/worker.ts
+++ b/src/lib/jobs/worker.ts
@@ -1,7 +1,7 @@
 /// <reference lib="webworker" />
 
 import { z } from "zod";
-import { ConfigSchema, Config } from "../helpers/config.ts";
+import { Config, ConfigSchema } from "../helpers/config.ts";
 import { BG, buildURL, GOOG_API_KEY, USER_AGENT } from "bgutils";
 import type { WebPoSignalOutput } from "bgutils";
 import { JSDOM } from "jsdom";
@@ -19,7 +19,9 @@ if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {
 }
 
 type FetchFunction = typeof fetch;
-const { getFetchClient }: { getFetchClient: (config: Config) => Promise<FetchFunction> } = await import(getFetchClientLocation);
+const { getFetchClient }: {
+    getFetchClient: (config: Config) => Promise<FetchFunction>;
+} = await import(getFetchClientLocation);
 
 // ---- Messages to send to the webworker ----
 const InputInitialiseSchema = z.object({
@@ -69,7 +71,7 @@ export const OutputMessageSchema = z.union([
 ]);
 type OutputMessage = z.infer<typeof OutputMessageSchema>;
 
-const IntegrityTokenResponse = z.tuple([ z.string() ]).rest(z.any());
+const IntegrityTokenResponse = z.tuple([z.string()]).rest(z.any());
 
 const isWorker = typeof WorkerGlobalScope !== "undefined" &&
     self instanceof WorkerGlobalScope;
@@ -85,7 +87,9 @@ if (isWorker) {
     onmessage = async (event) => {
         const message = InputMessageSchema.parse(event.data);
         if (message.type === "initialise") {
-            const fetchImpl: typeof fetch = await getFetchClient(message.config);
+            const fetchImpl: typeof fetch = await getFetchClient(
+                message.config,
+            );
             try {
                 const {
                     sessionPoToken,
@@ -226,7 +230,9 @@ async function setup(
             body: JSON.stringify([requestKey, botguardResponse]),
         },
     );
-    const integrityTokenBody = IntegrityTokenResponse.parse(await integrityTokenResponse.json());
+    const integrityTokenBody = IntegrityTokenResponse.parse(
+        await integrityTokenResponse.json(),
+    );
 
     const integrityTokenBasedMinter = await BG.WebPoMinter.create({
         integrityToken: integrityTokenBody[0],

--- a/src/lib/jobs/worker.ts
+++ b/src/lib/jobs/worker.ts
@@ -1,0 +1,218 @@
+/// <reference lib="webworker" />
+
+import { z } from "zod";
+import { ConfigSchema } from "../helpers/config.ts";
+import { BG, buildURL, GOOG_API_KEY, USER_AGENT } from "bgutils";
+import type { WebPoSignalOutput } from "bgutils";
+import { JSDOM } from "jsdom";
+import { Innertube } from "youtubei.js";
+let getFetchClientLocation = "getFetchClient";
+if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {
+    if (Deno.env.has("DENO_COMPILED")) {
+        getFetchClientLocation = Deno.mainModule.replace("src/main.ts", "") +
+            Deno.env.get("GET_FETCH_CLIENT_LOCATION");
+    } else {
+        getFetchClientLocation = Deno.env.get(
+            "GET_FETCH_CLIENT_LOCATION",
+        ) as string;
+    }
+}
+const { getFetchClient } = await import(getFetchClientLocation);
+
+// ---- Messages to send to the webworker ----
+const InputInitialiseSchema = z.object({
+    type: z.literal("initialise"),
+    config: ConfigSchema,
+}).strict();
+
+const InputContentTokenSchema = z.object({
+    type: z.literal("content-token-request"),
+    videoId: z.string(),
+    requestId: z.string().uuid(),
+}).strict();
+export type InputInitialise = z.infer<typeof InputInitialiseSchema>;
+export type InputContentToken = z.infer<typeof InputContentTokenSchema>;
+const InputMessageSchema = InputInitialiseSchema.or(InputContentTokenSchema);
+export type InputMessage = z.infer<typeof InputMessageSchema>;
+
+// ---- Messages that the webworker sends to the parent ----
+const OutputReadySchema = z.object({
+    type: z.literal("ready"),
+}).strict();
+
+const OutputInitialiseSchema = z.object({
+    type: z.literal("initialised"),
+    sessionPoToken: z.string(),
+    visitorData: z.string(),
+}).strict();
+
+const OutputContentTokenSchema = z.object({
+    type: z.literal("content-token"),
+    contentToken: z.string(),
+    requestId: InputContentTokenSchema.shape.requestId,
+}).strict();
+
+const OutputErrorSchema = z.object({
+    type: z.literal("error"),
+    error: z.any(),
+}).strict();
+export const OutputMessageSchema = OutputReadySchema.or(OutputInitialiseSchema)
+    .or(OutputContentTokenSchema).or(OutputErrorSchema);
+type OutputMessage = z.infer<typeof OutputMessageSchema>;
+
+const isWorker = typeof WorkerGlobalScope !== "undefined" &&
+    self instanceof WorkerGlobalScope;
+if (isWorker) {
+    // helper function to force type-checking
+    const untypedPostmessage = self.postMessage.bind(self);
+    const postMessage = (message: OutputMessage) => {
+        untypedPostmessage(message);
+    };
+
+    let minter: BG.WebPoMinter;
+
+    onmessage = async (event) => {
+        const message = InputMessageSchema.parse(event.data);
+        if (message.type === "initialise") {
+            const fetchImpl = await getFetchClient(message.config);
+            try {
+                const {
+                    sessionPoToken,
+                    visitorData,
+                    generatedMinter,
+                } = await setup({ fetchImpl });
+                minter = generatedMinter;
+                postMessage({
+                    type: "initialised",
+                    sessionPoToken,
+                    visitorData,
+                });
+            } catch (err) {
+                postMessage({ type: "error", error: err });
+            }
+        }
+        // this is called every time a video needs a content token
+        if (message.type === "content-token-request") {
+            if (!minter) {
+                throw new Error(
+                    "Minter not yet ready, must initialise first",
+                );
+            }
+            const contentToken = await minter.mintAsWebsafeString(
+                message.videoId,
+            );
+            postMessage({
+                type: "content-token",
+                contentToken,
+                requestId: message.requestId,
+            });
+        }
+    };
+
+    postMessage({ type: "ready" });
+}
+
+async function setup(
+    { fetchImpl }: { fetchImpl: ReturnType<typeof getFetchClient> },
+) {
+    const innertubeClient = await Innertube.create({
+        enable_session_cache: false,
+        user_agent: USER_AGENT,
+        retrieve_player: false,
+    });
+
+    const visitorData = innertubeClient.session.context.client.visitorData;
+
+    if (!visitorData) {
+        throw new Error("Could not get visitor data");
+    }
+
+    const dom = new JSDOM(
+        '<!DOCTYPE html><html lang="en"><head><title></title></head><body></body></html>',
+        {
+            url: "https://www.youtube.com/",
+            referrer: "https://www.youtube.com/",
+            userAgent: USER_AGENT,
+        },
+    );
+
+    Object.assign(globalThis, {
+        window: dom.window,
+        document: dom.window.document,
+        // location: dom.window.location, // --- doesn't seem to be necessary and the Web Worker doesn't like it
+        origin: dom.window.origin,
+    });
+
+    if (!Reflect.has(globalThis, "navigator")) {
+        Object.defineProperty(globalThis, "navigator", {
+            value: dom.window.navigator,
+        });
+    }
+
+    const challengeResponse = await innertubeClient.getAttestationChallenge(
+        "ENGAGEMENT_TYPE_UNBOUND",
+    );
+    if (!challengeResponse.bg_challenge) {
+        throw new Error("Could not get challenge");
+    }
+
+    const interpreterUrl = challengeResponse.bg_challenge.interpreter_url
+        .private_do_not_access_or_else_trusted_resource_url_wrapped_value;
+    const bgScriptResponse = await fetchImpl(
+        `http:${interpreterUrl}`,
+    );
+    const interpreterJavascript = await bgScriptResponse.text();
+
+    if (interpreterJavascript) {
+        new Function(interpreterJavascript)();
+    } else throw new Error("Could not load VM");
+
+    // Botguard currently surfaces a "Not implemented" error here, due to the environment
+    // not having a valid Canvas API in JSDOM. At the time of writing, this doesn't cause
+    // any issues as the Canvas check doesn't appear to be an enforced element of the checks
+    console.log(
+        '[INFO] the "Not implemented: HTMLCanvasElement.prototype.getContext" error is normal. Please do not open a bug report about it.',
+    );
+    const botguard = await BG.BotGuardClient.create({
+        program: challengeResponse.bg_challenge.program,
+        globalName: challengeResponse.bg_challenge.global_name,
+        globalObj: globalThis,
+    });
+
+    const webPoSignalOutput: WebPoSignalOutput = [];
+    const botguardResponse = await botguard.snapshot({ webPoSignalOutput });
+    const requestKey = "O43z0dpjhgX20SCx4KAo";
+
+    const integrityTokenResponse = await fetchImpl(
+        buildURL("GenerateIT", true),
+        {
+            method: "POST",
+            headers: {
+                "content-type": "application/json+protobuf",
+                "x-goog-api-key": GOOG_API_KEY,
+                "x-user-agent": "grpc-web-javascript/0.1",
+                "user-agent": USER_AGENT,
+            },
+            body: JSON.stringify([requestKey, botguardResponse]),
+        },
+    );
+    const response = await integrityTokenResponse.json() as unknown[];
+
+    if (typeof response[0] !== "string") {
+        throw new Error("Could not get integrity token");
+    }
+
+    const integrityTokenBasedMinter = await BG.WebPoMinter.create({
+        integrityToken: response[0],
+    }, webPoSignalOutput);
+
+    const sessionPoToken = await integrityTokenBasedMinter.mintAsWebsafeString(
+        visitorData,
+    );
+
+    return {
+        sessionPoToken,
+        visitorData,
+        generatedMinter: integrityTokenBasedMinter,
+    };
+}

--- a/src/lib/types/HonoVariables.ts
+++ b/src/lib/types/HonoVariables.ts
@@ -1,9 +1,9 @@
 import { Innertube } from "youtubei.js";
-import { BG } from "bgutils";
+import type { TokenMinter } from "../jobs/potoken.ts";
 import type { Config } from "../helpers/config.ts";
 
 export type HonoVariables = {
     innertubeClient: Innertube;
     config: Config;
-    tokenMinter: BG.WebPoMinter;
+    tokenMinter: TokenMinter;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,25 +22,6 @@ if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {
 }
 const { getFetchClient } = await import(getFetchClientLocation);
 
-setInterval(() => {
-    Deno.memoryUsage();
-    console.log(`[__MAIN] \
-heapUsed: ${
-        (Deno.memoryUsage().heapUsed / 1_000_000).toFixed(0).toString()
-            .padStart(4, " ")
-    }MB, \
-external: ${
-        (Deno.memoryUsage().external / 1_000_000).toFixed(0).toString()
-            .padStart(4, " ")
-    }MB, \
-rss: ${
-        (Deno.memoryUsage().rss / 1_000_000).toFixed(0).toString().padStart(
-            4,
-            " ",
-        )
-    }MB`);
-}, 1_000);
-
 declare module "hono" {
     interface ContextVariableMap extends HonoVariables {}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,25 @@ if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {
 }
 const { getFetchClient } = await import(getFetchClientLocation);
 
+setInterval(() => {
+    Deno.memoryUsage();
+    console.log(`[__MAIN] \
+heapUsed: ${
+        (Deno.memoryUsage().heapUsed / 1_000_000).toFixed(0).toString()
+            .padStart(4, " ")
+    }MB, \
+external: ${
+        (Deno.memoryUsage().external / 1_000_000).toFixed(0).toString()
+            .padStart(4, " ")
+    }MB, \
+rss: ${
+        (Deno.memoryUsage().rss / 1_000_000).toFixed(0).toString().padStart(
+            4,
+            " ",
+        )
+    }MB`);
+}, 1_000);
+
 declare module "hono" {
     interface ContextVariableMap extends HonoVariables {}
 }


### PR DESCRIPTION
Sets up an alternate approach to PO token generation where all of the dirty work (JSDOM, BotGuard handling etc) is put into a Web Worker. This allows us to terminate the web worker when a new PO token has been generated, helping to keep memory leaks in check. 

This isn't a perfect diagram, but it kind of gives you the sequence of events.
```mermaid
sequenceDiagram
    participant main as main.ts
    participant job as potoken.ts
    participant worker as [NEW] worker.ts
    participant old_worker as [PREVIOUS] worker.ts
    participant youtube as YouTube/BotGuard
    main->>job: Get new Tokens
    job->>worker: Spawn
    worker->>job: Ready
    job->>worker: Initialise (Pass config)
    worker->>youtube: generate valid token
    worker->>job: Initialised, ready to generate content tokens
    job->>job: Find video to check token against
    job->>worker: Request content token (Pass video ID)
    worker->>job: Respond with Content Token (Pass content token)
    job->>job: Check video gets 200
    job->>old_worker: Terminate
    job->>main: New PO token
```

Essentially, the po token job spawns up a new web worker and asks it to create a token and get ready. Once that's done, it gets a content token by sending a request to the worker to generate one. If that passes (200 on video load) then the worker is good.

If the worker is good, _all_ old workers are terminated, and the new worker is called whenever `tokenMinter` is called.

The token minter function is an async wrapper around the IPC-like call-and-response of events between POToken and Worker. The gist is that the worker receives a message asking it to generate a content token, with a video ID provided. It then posts a message with the newly generate content token. The minter function is just nice syntactic sugar around that process utilising promises. 

-----

Fixes #21