### PR TITLE
fix: cut off secret_key to 16 characters

### DIFF
--- a/src/lib/helpers/verifyRequest.ts
+++ b/src/lib/helpers/verifyRequest.ts
@@ -11,7 +11,7 @@ export const verifyRequest = (
     try {
         const decipher = new Ecb(
             Aes,
-            new TextEncoder().encode(config.server.secret_key),
+            new TextEncoder().encode(config.server.secret_key.substring(0, 16)),
             Padding.PKCS7,
         );
 


### PR DESCRIPTION
Maybe this was forgotten at the time of making https://github.com/iv-org/invidious-companion/commit/3464b0c833a742b911b7bf9200ed1563de822422?

Without it, the function errors with: `Error: Invalid key size (must be either 16, 24 or 32 bytes)`