### PR TITLE
fix: remove av01 specific filtering and just filter to non-video and mp4 video

### DIFF
--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -49,30 +49,10 @@ dashManifest.get("/:videoId", async (c) => {
     c.header("content-type", "application/dash+xml");
 
     if (videoInfo.streaming_data) {
-        // Invidious force quality only support one video codec at a time, using av01.
         // video.js only support MP4 not WEBM
         videoInfo.streaming_data.adaptive_formats = videoInfo
             .streaming_data.adaptive_formats
-            .filter((i) => {
-                if (i.mime_type.includes("mp4")) {
-                    if (
-                        i.has_video &&
-                        JSON.stringify(
-                            videoInfo.streaming_data?.adaptive_formats,
-                        ).includes("av01")
-                    ) {
-                        if (i.mime_type.includes("av01")) {
-                            return true;
-                        } else {
-                            return false;
-                        }
-                    } else {
-                        return true;
-                    }
-                } else {
-                    return false;
-                }
-            });
+            .filter((i) => i.has_video === false || i.mime_type.includes('mp4'));
 
         const player_response = videoInfo.page[0];
         // TODO: fix include storyboards in DASH manifest file

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -52,7 +52,9 @@ dashManifest.get("/:videoId", async (c) => {
         // video.js only support MP4 not WEBM
         videoInfo.streaming_data.adaptive_formats = videoInfo
             .streaming_data.adaptive_formats
-            .filter((i) => i.has_video === false || i.mime_type.includes('mp4'));
+            .filter((i) =>
+                i.has_video === false || i.mime_type.includes("mp4")
+            );
 
         const player_response = videoInfo.page[0];
         // TODO: fix include storyboards in DASH manifest file


### PR DESCRIPTION
as mentioned on https://github.com/iv-org/invidious-companion/issues/78

I can't see any breakages with the current videojs player on firefox or chrome with videos that have both av01 and avc1 codecs delivered. 

I've kept it filtering to MP4 and non-video elements.
This is working well on browser, clipious on mobile and clipious on android TV. 