### PR TITLE
chore: add options http method for videoplaybackproxy

### DIFF
--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -18,7 +18,7 @@ const { getFetchClient } = await import(getFetchClientLocation);
 
 const videoPlaybackProxy = new Hono();
 
-videoPlaybackProxy.options("/", async () => {
+videoPlaybackProxy.options("/", () => {
     const headersForResponse: Record<string, string> = {
         "access-control-allow-origin": "*",
         "access-control-allow-methods": "GET, OPTIONS",

--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -18,6 +18,18 @@ const { getFetchClient } = await import(getFetchClientLocation);
 
 const videoPlaybackProxy = new Hono();
 
+videoPlaybackProxy.options("/", async () => {
+    const headersForResponse: Record<string, string> = {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, OPTIONS",
+        "access-control-allow-headers": "Content-Type, Range",
+    };
+    return new Response("OK", {
+        status: 200,
+        headers: headersForResponse,
+    });
+});
+
 videoPlaybackProxy.get("/", async (c) => {
     const { host, c: client, expire, title } = c.req.query();
     const urlReq = new URL(c.req.url);


### PR DESCRIPTION
While checking the videoplayback proxy from Invidious: https://github.com/iv-org/invidious/blob/23ff6135bb4304c6b5e9de6fc06e67bfadc9651a/src/invidious/routes/video_playback.cr#L247-L252

I saw that we are not responding to the possible OPTIONS request for CORS preflight: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request

This seems to be important for all Firefox and Chrome version. Without that, the playback fails.