### PR TITLE
fix: Fix content-range header in video proxy for partial requests

### DIFF
--- a/src/lib/jobs/potoken.ts
+++ b/src/lib/jobs/potoken.ts
@@ -141,7 +141,7 @@ async function checkToken({
     instantiatedInnertubeClient: Innertube;
     config: Config;
     integrityTokenBasedMinter: TokenMinter;
-    metrics: Metrics | undefined,
+    metrics: Metrics | undefined;
 }) {
     const fetchImpl = getFetchClient(config);
 

--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -162,7 +162,9 @@ videoPlaybackProxy.get("/", async (c) => {
         const [firstByte, lastByte] = requestBytes.split("-");
         if (lastByte) {
             responseStatus = 206;
-            headersForResponse["content-range"] = `bytes ${requestBytes}/*`;
+            headersForResponse["content-range"] = `bytes ${requestBytes}/${
+                queryParams.get('clen') || '*'
+            }`;
         } else {
             // i.e. "bytes=0-", "bytes=600-"
             // full size of content is able to be calculated, so a full Content-Range header can be constructed

--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -163,7 +163,7 @@ videoPlaybackProxy.get("/", async (c) => {
         if (lastByte) {
             responseStatus = 206;
             headersForResponse["content-range"] = `bytes ${requestBytes}/${
-                queryParams.get('clen') || '*'
+                queryParams.get("clen") || "*"
             }`;
         } else {
             // i.e. "bytes=0-", "bytes=600-"


### PR DESCRIPTION
This should hopefully fix playback of the medium quality in iOS Safari, as it now only returns that the length is unknown when it is actually unknown.

Unlike desktop Firefox which requests the entire file with the range `0-`, iOS Safari uses partial requests, for which Invidious companion currently returns an unknown content length.

I haven't actually installed deno and tested if this fully fixes the problem but I have confirmed that the `clen` query parameter does exist for the medium quality on the `inv.nadeko.net` instance and just in case that query parameter is missing it will fallback to returning the `*` for unknown.