### PR TITLE
chore: sets a default timeout of 30 seconds on requests

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -31,10 +31,10 @@
  
 ###
 # Network call timeouts when talking to YouTube. 
-# Should only be used when connections are hanging unexpectedly.
+# Needed in order to ensure Deno closes hanging connections
 ###
 # [networking.fetch]
-# timeout_ms = 
+# timeout_ms = 30000
  
 ###
 # Network call retries when talking to YouTube, using

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -24,7 +24,7 @@ export const ConfigSchema = z.object({
         ump: z.boolean().default(false),
         proxy: z.string().nullable().default(Deno.env.get("PROXY") || null),
         fetch: z.object({
-            timeout_ms: z.number().optional(),
+            timeout_ms: z.number().default(30_000),
             retry: z.object({
                 enabled: z.boolean(),
                 times: z.number().optional(),


### PR DESCRIPTION
sets the default timeout to 30 seconds. This was causing issues because Deno doesn't ever close connections automatically. 