### PR TITLE
ci: update deno to 2.2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:debian-2.1.4 AS builder
+FROM denoland/deno:debian-2.2.10 AS builder
 
 ARG TINI_VERSION=0.19.0
 


### PR DESCRIPTION
Latest version is 2.2.8 but I prefer to update it to 2.2.5 since is the latest Deno version that I used on prod