### PR TITLE
fallback to other youtube clients in case of no adaptive formats (dash)

### DIFF
--- a/src/lib/helpers/youtubePlayerReq.ts
+++ b/src/lib/helpers/youtubePlayerReq.ts
@@ -55,7 +55,7 @@ export const youtubePlayerReq = async (
         contentPoToken,
     );
 
-    // Check if the first adaptive format URL is empty, if it it fallback to multiple YT clients
+    // Check if the first adaptive format URL is undefined, if it is then fallback to multiple YT clients
 
     if (
         !innertubeClientOauthEnabled &&

--- a/src/lib/helpers/youtubePlayerReq.ts
+++ b/src/lib/helpers/youtubePlayerReq.ts
@@ -4,6 +4,35 @@ import type { TokenMinter } from "../jobs/potoken.ts";
 
 import type { Config } from "./config.ts";
 
+function callWatchEndpoint(
+    videoId: string,
+    innertubeClient: Innertube,
+    innertubeClientType: string,
+    contentPoToken: string,
+) {
+    const watch_endpoint = new NavigationEndpoint({
+        watchEndpoint: { videoId: videoId },
+    });
+
+    return watch_endpoint.call(
+        innertubeClient.actions,
+        {
+            playbackContext: {
+                contentPlaybackContext: {
+                    vis: 0,
+                    splay: false,
+                    lactMilliseconds: "-1",
+                    signatureTimestamp: innertubeClient.session.player?.sts,
+                },
+            },
+            serviceIntegrityDimensions: {
+                poToken: contentPoToken,
+            },
+            client: innertubeClientType,
+        },
+    );
+}
+
 export const youtubePlayerReq = async (
     innertubeClient: Innertube,
     videoId: string,
@@ -17,24 +46,50 @@ export const youtubePlayerReq = async (
         innertubeClientUsed = "TV";
     }
 
-    const watch_endpoint = new NavigationEndpoint({
-        watchEndpoint: { videoId: videoId },
-    });
-
     const contentPoToken = await tokenMinter(videoId);
 
-    return watch_endpoint.call(innertubeClient.actions, {
-        playbackContext: {
-            contentPlaybackContext: {
-                vis: 0,
-                splay: false,
-                lactMilliseconds: "-1",
-                signatureTimestamp: innertubeClient.session.player?.sts,
-            },
-        },
-        serviceIntegrityDimensions: {
-            poToken: contentPoToken,
-        },
-        client: innertubeClientUsed,
-    });
+    const youtubePlayerResponse = await callWatchEndpoint(
+        videoId,
+        innertubeClient,
+        innertubeClientUsed,
+        contentPoToken,
+    );
+
+    // Check if the first adaptive format URL is empty, if it it fallback to multiple YT clients
+
+    if (
+        !innertubeClientOauthEnabled &&
+        youtubePlayerResponse.data.streamingData &&
+        youtubePlayerResponse.data.streamingData.adaptiveFormats[0].url ===
+            undefined
+    ) {
+        console.log(
+            "[WARNING] No URLs found for adaptive formats. Falling back to other YT clients.",
+        );
+        const innertubeClientsTypeFallback = ["MWEB", "TV"];
+
+        for await (const innertubeClientType of innertubeClientsTypeFallback) {
+            console.log(
+                `[WARNING] Trying fallback YT client ${innertubeClientType}`,
+            );
+            const youtubePlayerResponseFallback = await callWatchEndpoint(
+                videoId,
+                innertubeClient,
+                innertubeClientType,
+                contentPoToken,
+            );
+            if (
+                youtubePlayerResponseFallback.data.streamingData &&
+                youtubePlayerResponseFallback.data.streamingData
+                    .adaptiveFormats[0].url
+            ) {
+                youtubePlayerResponse.data.streamingData.adaptiveFormats =
+                    youtubePlayerResponseFallback.data.streamingData
+                        .adaptiveFormats;
+                break;
+            }
+        }
+    }
+
+    return youtubePlayerResponse;
 };


### PR DESCRIPTION
Should help with https://github.com/iv-org/invidious-companion/issues/60

When no adaptive formats are found, we try with other youtube clients.

If that worked, then we merge the youtube response from WEB client with the other client for only the adaptive formats URLs.

We try "MWEB" and "TVHTML5".