### PR TITLE
Fallback to TV yt client then MWEB

### DIFF
--- a/src/lib/helpers/youtubePlayerReq.ts
+++ b/src/lib/helpers/youtubePlayerReq.ts
@@ -66,7 +66,7 @@ export const youtubePlayerReq = async (
         console.log(
             "[WARNING] No URLs found for adaptive formats. Falling back to other YT clients.",
         );
-        const innertubeClientsTypeFallback = ["MWEB", "TV"];
+        const innertubeClientsTypeFallback = ["TV", "MWEB"];
 
         for await (const innertubeClientType of innertubeClientsTypeFallback) {
             console.log(


### PR DESCRIPTION
MWEB does not have multiple audios, where as TVHTML5 has. Switching the order of fallback retries.