### PR TITLE
feat: support for sensitive content videos

### DIFF
--- a/src/lib/helpers/youtubePlayerReq.ts
+++ b/src/lib/helpers/youtubePlayerReq.ts
@@ -11,7 +11,13 @@ function callWatchEndpoint(
     contentPoToken: string,
 ) {
     const watch_endpoint = new NavigationEndpoint({
-        watchEndpoint: { videoId: videoId },
+        watchEndpoint: {
+            videoId: videoId,
+            // Allow companion to gather sensitive content videos like
+            // `VuSU7PcEKpU`
+            racyCheckOk: true,
+            contentCheckOk: true,
+        },
     });
 
     return watch_endpoint.call(


### PR DESCRIPTION
Works well on the MWEB client (forcing it with `client_type: ClientType.MWEB,` on each `Innertube.create` for testing) and TV client (forcing the `client` on `watch_endpoint` to `"TV"` for testing).

I wasn't able to test with a recently uploaded video (which are the ones without DASH urls), but they should work.

Fixes: https://github.com/iv-org/invidious-companion/issues/51

Thanks to @absidue on https://github.com/iv-org/invidious-companion/issues/51#issuecomment-2780557907