### PR TITLE
return immediately if 403 is received on HEAD request

### DIFF
--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -118,6 +118,12 @@ videoPlaybackProxy.get("/", async (c) => {
             headers: headersToSend,
             redirect: "manual",
         });
+        if (googlevideoResponse.status == 403) {
+            return new Response(googlevideoResponse.body, {
+                status: googlevideoResponse.status,
+                statusText: googlevideoResponse.statusText,
+            });
+        }
         if (googlevideoResponse.headers.has("Location")) {
             location = googlevideoResponse.headers.get("Location") as string;
             continue;


### PR DESCRIPTION
Closes https://github.com/iv-org/invidious-companion/issues/111

Needs testing, but should work fine. This has been working on my invidious companion fork since April 22 (https://git.nadeko.net/Fijxu/invidious-companion-patches/src/branch/master/patches/0008-return-immediately-if-403-is-received-on-HEAD-reques.patch). In that patch I added the headers, I don't remember why, but they should be useless if we receive 403 on a HEAD request.