### PR TITLE
fix: fallback to WEB_EMBEDDED for videos that do not contain url

### DIFF
--- a/src/lib/helpers/youtubePlayerReq.ts
+++ b/src/lib/helpers/youtubePlayerReq.ts
@@ -72,7 +72,7 @@ export const youtubePlayerReq = async (
         console.log(
             "[WARNING] No URLs found for adaptive formats. Falling back to other YT clients.",
         );
-        const innertubeClientsTypeFallback = ["TV", "MWEB"];
+        const innertubeClientsTypeFallback = ["TV", "MWEB", "WEB_EMBEDDED"];
 
         for await (const innertubeClientType of innertubeClientsTypeFallback) {
             console.log(
@@ -85,9 +85,12 @@ export const youtubePlayerReq = async (
                 contentPoToken,
             );
             if (
-                youtubePlayerResponseFallback.data.streamingData &&
-                youtubePlayerResponseFallback.data.streamingData
-                    .adaptiveFormats[0].url
+                youtubePlayerResponseFallback.data.streamingData && (
+                    youtubePlayerResponseFallback.data.streamingData
+                        .adaptiveFormats[0].url ||
+                    youtubePlayerResponseFallback.data.streamingData
+                        .adaptiveFormats[0].signatureCipher
+                )
             ) {
                 youtubePlayerResponse.data.streamingData.adaptiveFormats =
                     youtubePlayerResponseFallback.data.streamingData


### PR DESCRIPTION
Workaround for https://github.com/iv-org/invidious-companion/issues/152

The `WEB_EMBEDDED` does not contain `url` on `adaptiveFormats`, but they contain a `signatureCipher` that contains the signature and the `url`, it can be deciphered and it works fine. This is still a workaround until we implement SABR on some way. I doubt this is going to last that much tho, but works for videos that do not have `url` on their `adaptiveFormats`.
