### PR TITLE
Remove fallback to `TV` client

### DIFF
--- a/src/lib/helpers/youtubePlayerReq.ts
+++ b/src/lib/helpers/youtubePlayerReq.ts
@@ -72,7 +72,7 @@ export const youtubePlayerReq = async (
         console.log(
             "[WARNING] No URLs found for adaptive formats. Falling back to other YT clients.",
         );
-        const innertubeClientsTypeFallback = ["TV", "TV_SIMPLY", "MWEB"];
+        const innertubeClientsTypeFallback = ["TV_SIMPLY", "MWEB"];
 
         for await (const innertubeClientType of innertubeClientsTypeFallback) {
             console.log(


### PR DESCRIPTION
Youtube started to serve DRM only streams on the `TV` client, youtube.js (companion dependency) is not able to decipher DRM urls. I recently noticed this on my instance (https://inv.nadeko.net) where a big percent of videos were unable to play because of failed deciphering.

Currently, `TV_SIMPLY` does not have DRM streams and contains multiple audio streams just like `TV` (`MWEB` does not contain multiple audio streams, so that is why we fallback into `TV_SIMPLY` first).