### PR TITLE
Pass inner fetch function implementation to worker local Innertube client

### DIFF
--- a/src/lib/jobs/worker.ts
+++ b/src/lib/jobs/worker.ts
@@ -139,6 +139,7 @@ async function setup(
 ) {
     const innertubeClient = await Innertube.create({
         enable_session_cache: false,
+        fetch: fetchImpl,
         user_agent: USER_AGENT,
         retrieve_player: false,
         cookie: innertubeClientCookies || undefined,


### PR DESCRIPTION
I've noticed the issue while trying to set up a proxy.

Proxy was not being used for innertubeClient.getAttestationChallenge call, and server could not start.

Just using the configured fetchImpl fixed the issue for me.

Fixes https://github.com/iv-org/invidious-companion/issues/165