### PR TITLE
set default base_path hono /companion + allow to customize it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,11 +119,12 @@ COPY --from=builder /app/invidious_companion ./
 
 ARG HOST PORT THC_VERSION TINI_VERSION
 EXPOSE "${PORT}/tcp"
+
 ENV SERVER_BASE_PATH=/companion \
     HOST="${HOST}" \
     PORT="${PORT}" \
     THC_PORT="${PORT}" \
-    THC_PATH="${SERVER_BASE_PATH:-/companion}/healthz" \
+    THC_PATH="/healthz" \
     THC_VERSION="${THC_VERSION}" \
     TINI_VERSION="${TINI_VERSION}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,10 +119,11 @@ COPY --from=builder /app/invidious_companion ./
 
 ARG HOST PORT THC_VERSION TINI_VERSION
 EXPOSE "${PORT}/tcp"
-ENV HOST="${HOST}" \
+ENV SERVER_BASE_URL=/companion \
+    HOST="${HOST}" \
     PORT="${PORT}" \
     THC_PORT="${PORT}" \
-    THC_PATH='/healthz' \
+    THC_PATH="${SERVER_BASE_URL}/healthz" \
     THC_VERSION="${THC_VERSION}" \
     TINI_VERSION="${TINI_VERSION}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ COPY --from=builder /app/invidious_companion ./
 
 ARG HOST PORT THC_VERSION TINI_VERSION
 EXPOSE "${PORT}/tcp"
-ENV SERVER_BASE_URL=/companion \
+ENV SERVER_BASE_PATH=/companion \
     HOST="${HOST}" \
     PORT="${PORT}" \
     THC_PORT="${PORT}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ ENV SERVER_BASE_URL=/companion \
     HOST="${HOST}" \
     PORT="${PORT}" \
     THC_PORT="${PORT}" \
-    THC_PATH="${SERVER_BASE_URL}/healthz" \
+    THC_PATH="${SERVER_BASE_PATH:-/companion}/healthz" \
     THC_VERSION="${THC_VERSION}" \
     TINI_VERSION="${TINI_VERSION}"
 

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -15,6 +15,8 @@
 # # Listens to a unix socket on instead of a TCP socket
 # use_unix_socket = false # env variable: SERVER_USE_UNIX_SOCKET
 # unix_socket_path = "/tmp/invidious-companion.sock" # env variable: SERVER_UNIX_SOCKET_PATH
+# # Base path Invidious companion will serve from
+# base_path = "/companion" # env variable: SERVER_BASE_PATH
 # # secret key needs to be exactly 16 characters long
 # secret_key = "CHANGE_ME" # env variable: SERVER_SECRET_KEY
 # verify_requests = false # env variable: SERVER_VERIFY_REQUESTS

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -12,9 +12,29 @@ export const ConfigSchema = z.object({
             Deno.env.get("SERVER_UNIX_SOCKET_PATH") ||
                 "/tmp/invidious-companion.sock",
         ),
-        base_path: z.string().default(
-            Deno.env.get("SERVER_BASE_PATH") || "/companion",
-        ),
+        base_path: z.string()
+            .default(Deno.env.get("SERVER_BASE_PATH") || "/companion")
+            .refine(
+                (path) => path.startsWith("/"),
+                {
+                    message:
+                        "SERVER_BASE_PATH must start with a forward slash (/). Example: '/companion'",
+                },
+            )
+            .refine(
+                (path) => !path.endsWith("/") || path === "/",
+                {
+                    message:
+                        "SERVER_BASE_PATH must not end with a forward slash (/) unless it's the root path. Example: '/companion' not '/companion/'",
+                },
+            )
+            .refine(
+                (path) => !path.includes("//"),
+                {
+                    message:
+                        "SERVER_BASE_PATH must not contain double slashes (//). Example: '/companion' not '//companion' or '/comp//anion'",
+                },
+            ),
         secret_key: z.string().length(16).default(
             Deno.env.get("SERVER_SECRET_KEY") || "",
         ),

--- a/src/lib/helpers/config.ts
+++ b/src/lib/helpers/config.ts
@@ -12,6 +12,9 @@ export const ConfigSchema = z.object({
             Deno.env.get("SERVER_UNIX_SOCKET_PATH") ||
                 "/tmp/invidious-companion.sock",
         ),
+        base_path: z.string().default(
+            Deno.env.get("SERVER_BASE_PATH") || "/companion",
+        ),
         secret_key: z.string().length(16).default(
             Deno.env.get("SERVER_SECRET_KEY") || "",
         ),

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ declare module "hono" {
 
 const app = new Hono({
     getPath: (req) => new URL(req.url).pathname,
-});
+}).basePath(config.server.base_path);
 const metrics = config.server.enable_metrics ? new Metrics() : undefined;
 
 let tokenMinter: TokenMinter;

--- a/src/main.ts
+++ b/src/main.ts
@@ -164,6 +164,7 @@ export function run(signal: AbortSignal, port: number, hostname: string) {
         const srv = Deno.serve(
             {
                 onListen() {
+                    Deno.chmodSync(udsPath, 0o777);
                     console.log(
                         `[INFO] Server successfully started at ${udsPath} with permissions set to 777.`,
                     );
@@ -173,8 +174,6 @@ export function run(signal: AbortSignal, port: number, hostname: string) {
             },
             app.fetch,
         );
-
-        Deno.chmodSync(udsPath, 0o777);
 
         return srv;
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,19 +156,33 @@ export function run(signal: AbortSignal, port: number, hostname: string) {
         }
 
         const srv = Deno.serve(
-            { signal: signal, path: udsPath },
+            {
+                onListen() {
+                    console.log(
+                        `[INFO] Server successfully started at ${udsPath} with permissions set to 777.`,
+                    );
+                },
+                signal: signal,
+                path: udsPath,
+            },
             app.fetch,
         );
 
-        console.log(
-            `[INFO] Setting unix domain socket '${udsPath}' permissions to 777`,
-        );
         Deno.chmodSync(udsPath, 0o777);
 
         return srv;
     } else {
         return Deno.serve(
-            { signal: signal, port: port, hostname: hostname },
+            {
+                onListen() {
+                    console.log(
+                        `[INFO] Server successfully started at http://${config.server.host}:${config.server.port}${config.server.base_path}`,
+                    );
+                },
+                signal: signal,
+                port: port,
+                hostname: hostname,
+            },
             app.fetch,
         );
     }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,7 +8,6 @@ import invidiousRouteDashManifest from "./invidious_routes/dashManifest.ts";
 import invidiousCaptionsApi from "./invidious_routes/captions.ts";
 import getDownloadHandler from "./invidious_routes/download.ts";
 import videoPlaybackProxy from "./videoPlaybackProxy.ts";
-import health from "./health.ts";
 import type { Config } from "../lib/helpers/config.ts";
 import metrics from "./metrics.ts";
 
@@ -41,7 +40,6 @@ export const routes = (
     app.route("/api/manifest/dash/id", invidiousRouteDashManifest);
     app.route("/api/v1/captions", invidiousCaptionsApi);
     app.route("/videoplayback", videoPlaybackProxy);
-    app.route("/healthz", health);
     if (config.server.enable_metrics) {
         app.route("/metrics", metrics);
     }

--- a/src/routes/invidious_routes/captions.ts
+++ b/src/routes/invidious_routes/captions.ts
@@ -64,7 +64,7 @@ captionsHandler.get("/:videoId", async (c) => {
             invidiousAvailableCaptionsArr.push({
                 label: caption_track.name.text || "",
                 languageCode: caption_track.language_code,
-                url: `/api/v1/captions/${videoId}?label=${
+                url: `${config.server.base_path}/api/v1/captions/${videoId}?label=${
                     encodeURIComponent(caption_track.name.text || "")
                 }`,
             });

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -93,7 +93,7 @@ dashManifest.get("/:videoId", async (c) => {
                         queryParams.set("enc", "true");
                         queryParams.set("data", encryptedParams);
                     }
-                    dashUrl = (dashUrl.pathname + "?" +
+                    dashUrl = (config.server.base_path + dashUrl.pathname + "?" +
                         queryParams.toString()) as unknown as URL;
                     return dashUrl;
                 } else {

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -93,8 +93,9 @@ dashManifest.get("/:videoId", async (c) => {
                         queryParams.set("enc", "true");
                         queryParams.set("data", encryptedParams);
                     }
-                    dashUrl = (config.server.base_path + dashUrl.pathname + "?" +
-                        queryParams.toString()) as unknown as URL;
+                    dashUrl =
+                        (config.server.base_path + dashUrl.pathname + "?" +
+                            queryParams.toString()) as unknown as URL;
                     return dashUrl;
                 } else {
                     return dashUrl;

--- a/src/routes/invidious_routes/download.ts
+++ b/src/routes/invidious_routes/download.ts
@@ -62,7 +62,7 @@ export default function getDownloadHandler(app: Hono) {
 
         if ("label" in downloadWidgetData) {
             return await app.request(
-                `/api/v1/captions/${videoId}?label=${
+                `${config.server.base_path}/api/v1/captions/${videoId}?label=${
                     encodeURIComponent(downloadWidgetData.label)
                 }`,
             );
@@ -84,7 +84,7 @@ export default function getDownloadHandler(app: Hono) {
             urlQueriesForLatestVersion.set("local", "true");
 
             return await app.request(
-                `/latest_version?${urlQueriesForLatestVersion.toString()}`,
+                `${config.server.base_path}/latest_version?${urlQueriesForLatestVersion.toString()}`,
             );
         }
     }

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -88,7 +88,6 @@ latestVersion.get("/", async (c) => {
             urlToRedirect = config.server.base_path + itagUrlParsed.pathname +
                 "?" +
                 queryParams.toString();
-            console.log(urlToRedirect);
         }
 
         if (title) urlToRedirect += `&title=${encodeURIComponent(title)}`;

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -85,8 +85,9 @@ latestVersion.get("/", async (c) => {
                 queryParams.set("enc", "true");
                 queryParams.set("data", encryptedParams);
             }
-            urlToRedirect = itagUrlParsed.pathname + "?" +
+            urlToRedirect = config.server.base_path + itagUrlParsed.pathname + "?" +
                 queryParams.toString();
+            console.log(urlToRedirect)
         }
 
         if (title) urlToRedirect += `&title=${encodeURIComponent(title)}`;

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -85,9 +85,10 @@ latestVersion.get("/", async (c) => {
                 queryParams.set("enc", "true");
                 queryParams.set("data", encryptedParams);
             }
-            urlToRedirect = config.server.base_path + itagUrlParsed.pathname + "?" +
+            urlToRedirect = config.server.base_path + itagUrlParsed.pathname +
+                "?" +
                 queryParams.toString();
-            console.log(urlToRedirect)
+            console.log(urlToRedirect);
         }
 
         if (title) urlToRedirect += `&title=${encodeURIComponent(title)}`;

--- a/src/tests/main_test.ts
+++ b/src/tests/main_test.ts
@@ -1,7 +1,7 @@
 Deno.env.set("SERVER_SECRET_KEY", "aaaaaaaaaaaaaaaa");
 const { run } = await import("../main.ts");
 
-import { parseConfig } from "../lib/helpers/config.ts";
+const { parseConfig } = await import("../lib/helpers/config.ts");
 const config = await parseConfig();
 
 import { dashManifest } from "./dashManifest.ts";

--- a/src/tests/main_test.ts
+++ b/src/tests/main_test.ts
@@ -10,7 +10,7 @@ Deno.test({
     async fn(t) {
         const controller = new AbortController();
         const port = 8282;
-        const baseUrl = `http://localhost:${port.toString()}`;
+        const baseUrl = `http://localhost:${port.toString()}/companion`;
         const headers = { Authorization: "Bearer aaaaaaaaaaaaaaaa" };
 
         await run(

--- a/src/tests/main_test.ts
+++ b/src/tests/main_test.ts
@@ -1,6 +1,9 @@
 Deno.env.set("SERVER_SECRET_KEY", "aaaaaaaaaaaaaaaa");
 const { run } = await import("../main.ts");
 
+import { parseConfig } from "../lib/helpers/config.ts";
+const config = await parseConfig();
+
 import { dashManifest } from "./dashManifest.ts";
 import { youtubePlayer } from "./youtubePlayer.ts";
 import { latestVersion } from "./latestVersion.ts";
@@ -9,14 +12,13 @@ Deno.test({
     name: "Checking if Invidious companion works",
     async fn(t) {
         const controller = new AbortController();
-        const port = 8282;
-        const baseUrl = `http://localhost:${port.toString()}/companion`;
+        const baseUrl = `http://${config.server.host}:${config.server.port.toString()}${config.server.base_path}`;
         const headers = { Authorization: "Bearer aaaaaaaaaaaaaaaa" };
 
         await run(
             controller.signal,
-            port,
-            "localhost",
+            config.server.port,
+            config.server.host,
         );
 
         await t.step(

--- a/src/tests/main_test.ts
+++ b/src/tests/main_test.ts
@@ -12,7 +12,8 @@ Deno.test({
     name: "Checking if Invidious companion works",
     async fn(t) {
         const controller = new AbortController();
-        const baseUrl = `http://${config.server.host}:${config.server.port.toString()}${config.server.base_path}`;
+        const baseUrl =
+            `http://${config.server.host}:${config.server.port.toString()}${config.server.base_path}`;
         const headers = { Authorization: "Bearer aaaaaaaaaaaaaaaa" };
 
         await run(


### PR DESCRIPTION
fixes #118 

linked to https://github.com/iv-org/invidious/pull/5266

This commit set the default base_path to `/companion`. The benefits are:
- one route for all things about companion, easier for configuring the reverse proxy. less error-prone.
- will be easier to implement `proxy the requests from invidious to companion if public_url is not configured. In order to avoid having to touch the reverse proxy.` from https://github.com/iv-org/invidious/issues/5215  
  because there will only need one route to create in invidious instead of multiples one (/latest_version and so on)
- since all the paths will be under one route, we can add easily new paths without asking the user to update their reverse proxy

The big downside:
- This will set the default base_path to /companion, so all current setups will need to update their config or set the base_path to `/`.  
  But I think this is okay wise, since companion hasn't fully landed into the core of invidious.  
  I'll do an announcement about it.