### PR TITLE
Refactor hono routes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { routes } from "./routes/index.ts";
+import { miscRoutes, companionRoutes } from "./routes/index.ts";
 import { Innertube } from "youtubei.js";
 import { poTokenGenerate, type TokenMinter } from "./lib/jobs/potoken.ts";
 import { USER_AGENT } from "bgutils";
@@ -11,7 +11,6 @@ import { existsSync } from "@std/fs/exists";
 import { parseConfig } from "./lib/helpers/config.ts";
 const config = await parseConfig();
 import { Metrics } from "./lib/helpers/metrics.ts";
-import health from "./routes/health.ts";
 
 const args = parseArgs(Deno.args);
 
@@ -138,9 +137,14 @@ companionApp.use("*", async (c, next) => {
     c.set("metrics", metrics);
     await next();
 });
-routes(companionApp, config);
+companionRoutes(companionApp, config);
 
-app.route("/healthz", health);
+app.use("*", async (c, next) => {
+    c.set("metrics", metrics);
+    await next();
+});
+miscRoutes(app, config)
+
 app.route("/", companionApp);
 
 // This cannot be changed since companion restricts the

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { miscRoutes, companionRoutes } from "./routes/index.ts";
+import { companionRoutes, miscRoutes } from "./routes/index.ts";
 import { Innertube } from "youtubei.js";
 import { poTokenGenerate, type TokenMinter } from "./lib/jobs/potoken.ts";
 import { USER_AGENT } from "bgutils";
@@ -143,7 +143,7 @@ app.use("*", async (c, next) => {
     c.set("metrics", metrics);
     await next();
 });
-miscRoutes(app, config)
+miscRoutes(app, config);
 
 app.route("/", companionApp);
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,8 +10,9 @@ import getDownloadHandler from "./invidious_routes/download.ts";
 import videoPlaybackProxy from "./videoPlaybackProxy.ts";
 import type { Config } from "../lib/helpers/config.ts";
 import metrics from "./metrics.ts";
+import health from "./health.ts";
 
-export const routes = (
+export const companionRoutes = (
     app: Hono,
     config: Config,
 ) => {
@@ -40,6 +41,13 @@ export const routes = (
     app.route("/api/manifest/dash/id", invidiousRouteDashManifest);
     app.route("/api/v1/captions", invidiousCaptionsApi);
     app.route("/videoplayback", videoPlaybackProxy);
+};
+
+export const miscRoutes = (
+    app: Hono,
+    config: Config,
+) => {
+    app.route("/healthz", health);
     if (config.server.enable_metrics) {
         app.route("/metrics", metrics);
     }


### PR DESCRIPTION
In https://github.com/iv-org/invidious-companion/commit/25f1b1980736d70c92ba4815cda200569ad91921, the `/metrics` route got moved to `/companion/metrics`, I assume this was not an intended change, so I did this to keep routes unrelated to Youtube requests more organized