### PR TITLE
Fix error 500 in captions

### DIFF
--- a/src/lib/helpers/youtubeTranscriptsHandling.ts
+++ b/src/lib/helpers/youtubeTranscriptsHandling.ts
@@ -64,11 +64,13 @@ export async function handleTranscripts(
 
         const start_ms = createTemporalDuration(Number(line.start_ms)).round({
             largestUnit: "year",
+            relativeTo: Temporal.PlainDateTime.from("2022-01-01"),
             //@ts-ignore see above
         }).toLocaleString("en-US", timestampFormatOptions);
 
         const end_ms = createTemporalDuration(Number(line.end_ms)).round({
             largestUnit: "year",
+            relativeTo: Temporal.PlainDateTime.from("2022-01-01"),
             //@ts-ignore see above
         }).toLocaleString("en-US", timestampFormatOptions);
         const timestamp = `${start_ms} --> ${end_ms}`;


### PR DESCRIPTION
Closes https://github.com/iv-org/invidious-companion/issues/207

Seems like relativeTo was required for largestUnit to fix in Temporal.Duration.round(). I'm not really sure to be honest but this fixed it ;)