### PR TITLE
Randomise search parameters to avoid detection patterns (#236)

### DIFF
--- a/src/lib/jobs/potoken.ts
+++ b/src/lib/jobs/potoken.ts
@@ -149,11 +149,24 @@ async function checkToken({
     const fetchImpl = getFetchClient(config);
 
     try {
-        console.log("[INFO] Searching for videos to validate PO token");
-        const searchResults = await instantiatedInnertubeClient.search("news", {
+        // Randomize search parameters to avoid detection patterns
+        const searchQueries = [
+            "news", "music", "gaming", "tech", "education", "science", "entertainment", "sports",
+            "cooking", "travel", "fitness", "art", "movies", "comedy", "documentary", "tutorial",
+            "review", "vlog", "podcast", "interview", "nature", "animals", "history", "diy"
+        ];
+        const uploadDateOptions = ["hour", "today", "week", "month"] as const;
+        const durationOptions = ["medium", "long"] as const;
+
+        const searchQuery = searchQueries[Math.floor(Math.random() * searchQueries.length)];
+        const uploadDate = uploadDateOptions[Math.floor(Math.random() * uploadDateOptions.length)];
+        const duration = durationOptions[Math.floor(Math.random() * durationOptions.length)];
+
+        console.log(`[INFO] Searching for videos to validate PO token (query: "${searchQuery}", upload_date: "${uploadDate}", duration: "${duration}")`);
+        const searchResults = await instantiatedInnertubeClient.search(searchQuery, {
             type: "video",
-            upload_date: "week",
-            duration: "medium",
+            upload_date: uploadDate,
+            duration: duration,
         });
 
         // Get all videos that have an id property and shuffle them randomly

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,11 @@ if (!innertubeClientOauthEnabled) {
         config.jobs.youtube_session.frequency,
         { backoffSchedule: [5_000, 15_000, 60_000, 180_000] },
         async () => {
+            // Add random jitter (0-60 seconds) to avoid synchronized requests across instances
+            const jitterMs = Math.floor(Math.random() * 60_000);
+            console.log(`[INFO] Adding ${jitterMs}ms jitter before regenerating session`);
+            await new Promise(resolve => setTimeout(resolve, jitterMs));
+
             if (innertubeClientJobPoTokenEnabled) {
                 try {
                     ({ innertubeClient, tokenMinter } = await poTokenGenerate(


### PR DESCRIPTION
Implements multiple anti-detection strategies to prevent YouTube from blocking repetitive searches:
- Randomise search queries (24 diverse terms instead of fixed "news")
- Randomise upload_date filter (hour, today, week, month)
- Randomise duration filter (medium, long)
- Adds timing jitter (0-60s) to cron job to desynchronize requests across instances

Fixes #236
