### PR TITLE
Fix OAuth mode not working due to missing tokenMinter

### DIFF
--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -31,7 +31,7 @@ export const youtubePlayerParsing = async ({
     innertubeClient: Innertube;
     videoId: string;
     config: Config;
-    tokenMinter: TokenMinter;
+    tokenMinter: TokenMinter | undefined;
     metrics: Metrics | undefined;
     overrideCache?: boolean;
 }): Promise<object> => {

--- a/src/lib/helpers/youtubePlayerReq.ts
+++ b/src/lib/helpers/youtubePlayerReq.ts
@@ -32,9 +32,12 @@ function callWatchEndpoint(
                         ?.signature_timestamp,
                 },
             },
-            serviceIntegrityDimensions: {
-                poToken: contentPoToken,
-            },
+            // Only include serviceIntegrityDimensions if we have a PO token
+            ...(contentPoToken && {
+                serviceIntegrityDimensions: {
+                    poToken: contentPoToken,
+                },
+            }),
             client: innertubeClientType,
         },
     );
@@ -44,7 +47,7 @@ export const youtubePlayerReq = async (
     innertubeClient: Innertube,
     videoId: string,
     config: Config,
-    tokenMinter: TokenMinter,
+    tokenMinter: TokenMinter | undefined,
 ): Promise<ApiResponse> => {
     const innertubeClientOauthEnabled = config.youtube_session.oauth_enabled;
 
@@ -53,7 +56,10 @@ export const youtubePlayerReq = async (
         innertubeClientUsed = "TV";
     }
 
-    const contentPoToken = await tokenMinter(videoId);
+    // Only generate PO token if not using OAuth and tokenMinter is available
+    const contentPoToken = !innertubeClientOauthEnabled && tokenMinter
+        ? await tokenMinter(videoId)
+        : "";
 
     const youtubePlayerResponse = await callWatchEndpoint(
         videoId,

--- a/src/routes/invidious_routes/captions.ts
+++ b/src/routes/invidious_routes/captions.ts
@@ -32,8 +32,10 @@ captionsHandler.get("/:videoId", async (c) => {
         });
     }
 
-    // Check if tokenMinter is ready (only needed when PO token is enabled)
-    if (config.jobs.youtube_session.po_token_enabled && !tokenMinter) {
+    // Check if tokenMinter is ready (only needed when PO token is enabled and OAuth is not)
+    if (config.jobs.youtube_session.po_token_enabled &&
+        !config.youtube_session.oauth_enabled &&
+        !tokenMinter) {
         throw new HTTPException(503, {
             res: new Response(TOKEN_MINTER_NOT_READY_MESSAGE),
         });

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -22,8 +22,10 @@ dashManifest.get("/:videoId", async (c) => {
     const metrics = c.get("metrics");
     const tokenMinter = c.get("tokenMinter");
 
-    // Check if tokenMinter is ready (only needed when PO token is enabled)
-    if (config.jobs.youtube_session.po_token_enabled && !tokenMinter) {
+    // Check if tokenMinter is ready (only needed when PO token is enabled and OAuth is not)
+    if (config.jobs.youtube_session.po_token_enabled &&
+        !config.youtube_session.oauth_enabled &&
+        !tokenMinter) {
         throw new HTTPException(503, {
             res: new Response(TOKEN_MINTER_NOT_READY_MESSAGE),
         });

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -32,8 +32,10 @@ latestVersion.get("/", async (c) => {
     const metrics = c.get("metrics");
     const tokenMinter = c.get("tokenMinter");
 
-    // Check if tokenMinter is ready (only needed when PO token is enabled)
-    if (config.jobs.youtube_session.po_token_enabled && !tokenMinter) {
+    // Check if tokenMinter is ready (only needed when PO token is enabled and OAuth is not)
+    if (config.jobs.youtube_session.po_token_enabled &&
+        !config.youtube_session.oauth_enabled &&
+        !tokenMinter) {
         throw new HTTPException(503, {
             res: new Response(TOKEN_MINTER_NOT_READY_MESSAGE),
         });

--- a/src/routes/youtube_api_routes/player.ts
+++ b/src/routes/youtube_api_routes/player.ts
@@ -13,8 +13,10 @@ player.post("/player", async (c) => {
     const metrics = c.get("metrics");
     const tokenMinter = c.get("tokenMinter");
 
-    // Check if tokenMinter is ready (only needed when PO token is enabled)
-    if (config.jobs.youtube_session.po_token_enabled && !tokenMinter) {
+    // Check if tokenMinter is ready (only needed when PO token is enabled and OAuth is not)
+    if (config.jobs.youtube_session.po_token_enabled &&
+        !config.youtube_session.oauth_enabled &&
+        !tokenMinter) {
         return c.json({
             playabilityStatus: {
                 status: "ERROR",


### PR DESCRIPTION
## Summary
When OAuth is enabled (`YOUTUBE_SESSION_OAUTH_ENABLED=true`), the companion fails with 503 errors because the PO token generation is skipped but several endpoints still require `tokenMinter` to be set.

This fix:
- Makes `tokenMinter` optional in function signatures
- Updates endpoint checks to skip `tokenMinter` requirement when OAuth is enabled  
- Conditionally includes `serviceIntegrityDimensions` only when a PO token exists

## Changes
- `src/lib/helpers/youtubePlayerReq.ts` - Make tokenMinter optional, skip PO token generation in OAuth mode
- `src/lib/helpers/youtubePlayerHandling.ts` - Update type signature
- `src/routes/invidious_routes/latestVersion.ts` - Add OAuth check to 503 condition
- `src/routes/invidious_routes/dashManifest.ts` - Add OAuth check to 503 condition
- `src/routes/invidious_routes/captions.ts` - Add OAuth check to 503 condition
- `src/routes/youtube_api_routes/player.ts` - Add OAuth check to error condition

## Test plan
1. Enable OAuth mode: `YOUTUBE_SESSION_OAUTH_ENABLED=true`
2. Authenticate via the device code flow
3. Verify `/companion/latest_version` returns 302 instead of 503
4. Verify age-restricted videos work with OAuth authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)