### PR TITLE
fix: close Deno.HttpClient after use to prevent memory leak

### DIFF
--- a/src/lib/helpers/getFetchClient.ts
+++ b/src/lib/helpers/getFetchClient.ts
@@ -44,7 +44,17 @@ export const getFetchClient = (config: Config): {
                 method: init?.method,
                 body: init?.body,
             });
-            return new Response(fetchRes.body, {
+
+            // Pipe the body through a TransformStream to close the client when done
+            const { readable, writable } = new TransformStream();
+            const bodyStream = fetchRes.body;
+            if (bodyStream) {
+                bodyStream.pipeTo(writable).finally(() => client.close());
+            } else {
+                client.close();
+            }
+
+            return new Response(bodyStream ? readable : null, {
                 status: fetchRes.status,
                 headers: fetchRes.headers,
             });


### PR DESCRIPTION
Fix memory leak found by Claude.

> Every call to getFetchClient(config) when proxy or IPv6 rotation is configured creates a new Deno.HttpClient via Deno.createHttpClient() — but never calls client.close(). Since onesiePlayerReq calls 
getFetchClient per request, and each onesie request can trigger 1-3 fetches internally, this leaks native TCP/TLS resources quickly.
> ```
> // Current code — client is never closed:
> const client = Deno.createHttpClient(clientOptions);
> const fetchRes = await fetchShim(config, input, { client, ... });
> return new Response(fetchRes.body, { ... }); // original response abandoned too
> ```