### PR TITLE
chore: Remove chunking from video playback proxy

### DIFF
--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -140,58 +140,15 @@ videoPlaybackProxy.get("/", async (c) => {
         });
     }
 
-    // =================== REQUEST CHUNKING =======================
-    // if the requested response is larger than the chunkSize, break up the response
-    // into chunks and stream the response back to the client to avoid rate limiting
-    const { readable, writable } = new TransformStream();
-    const stream = new StreamingApi(writable, readable);
     const googleVideoUrl = new URL(location);
-    const getChunk = async (start: number, end: number) => {
-        googleVideoUrl.searchParams.set(
-            "range",
-            `${start}-${end}`,
-        );
-        const postResponse = await fetchClient(googleVideoUrl, {
-            method: "POST",
-            body: new Uint8Array([0x78, 0]), // protobuf: { 15: 0 } (no idea what it means but this is what YouTube uses),
-            headers: headersToSend,
-        });
-        if (postResponse.status !== 200) {
-            throw new Error("Non-200 response from google servers");
-        }
-        await stream.pipe(postResponse.body);
-    };
-
-    const chunkSize =
-        config.networking.videoplayback.video_fetch_chunk_size_mb * 1_000_000;
-    const totalBytes = Number(
-        headResponse.headers.get("Content-Length") || "0",
-    );
-
-    // if no range sent, the client wants thw whole file, i.e. for downloads
-    const wholeRequestStartByte = Number(firstByte || "0");
-    const wholeRequestEndByte = wholeRequestStartByte + Number(totalBytes) - 1;
-
-    let chunk = Promise.resolve();
-    for (
-        let startByte = wholeRequestStartByte;
-        startByte < wholeRequestEndByte;
-        startByte += chunkSize
-    ) {
-        // i.e.
-        // 0 - 4_999_999, then
-        // 5_000_000 - 9_999_999, then
-        // 10_000_000 - 14_999_999
-        let endByte = startByte + chunkSize - 1;
-        if (endByte > wholeRequestEndByte) {
-            endByte = wholeRequestEndByte;
-        }
-        chunk = chunk.then(() => getChunk(startByte, endByte));
-    }
-    chunk.catch(() => {
-        stream.abort();
+    const postResponse = await fetchClient(googleVideoUrl, {
+        method: "POST",
+        body: new Uint8Array([0x78, 0]), // protobuf: { 15: 0 } (no idea what it means but this is what YouTube uses),
+        headers: headersToSend,
     });
-    // =================== REQUEST CHUNKING =======================
+    if (postResponse.status !== 200) {
+        throw new Error("Non-200 response from google servers");
+    }
 
     const headersForResponse: Record<string, string> = {
         "content-length": headResponse.headers.get("content-length") || "",
@@ -236,7 +193,7 @@ videoPlaybackProxy.get("/", async (c) => {
         }
     }
 
-    return new Response(stream.responseReadable, {
+    return new Response(postResponse.body, {
         status: responseStatus,
         statusText: headResponse.statusText,
         headers: headersForResponse,

--- a/src/routes/videoPlaybackProxy.ts
+++ b/src/routes/videoPlaybackProxy.ts
@@ -2,7 +2,6 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { encodeRFC5987ValueChars } from "../lib/helpers/encodeRFC5987ValueChars.ts";
 import { decryptQuery } from "../lib/helpers/encryptQuery.ts";
-import { StreamingApi } from "hono/utils/stream";
 
 let getFetchClientLocation = "getFetchClient";
 if (Deno.env.get("GET_FETCH_CLIENT_LOCATION")) {


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious-companion/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [x] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [ ] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
<!-- e.g. GLM-5.2, MiniMax-M3, DeepSeek V4 Pro, Kimi K2.7 Code... -->

**Tool(s) used:**
<!-- e.g. OpenCode, OpenChamber, Cline, Pi, Open WebUI... -->

**How was AI used?**
<!-- If you selected "AI was used to partially create this pull request" above, explain how AI was used here. Leave empty otherwise. -->

---

## Pull request description

Fixes an issue when loading videos that appeared when using Deno >=2.8.2. for some reason, chunking is adding some sort of delay when trying to load videos, the reason is unknown for now, and since chunking is not essential, we are removing this feature for now.

Fixes: https://github.com/iv-org/invidious/issues/5779