### PR TITLE
fix: open Deno KV at a writable path to fix PermissionDenied (#330)

### DIFF
--- a/src/lib/helpers/kv.ts
+++ b/src/lib/helpers/kv.ts
@@ -1,0 +1,27 @@
+import type { Config } from "./config.ts";
+
+// Deno 2.9 moved the no-argument Deno.openKv() default store to a
+// per-app OS data directory (e.g. $XDG_DATA_HOME) instead of DENO_DIR,
+// which is neither in the compiled binary's --allow-write allowlist
+// (see deno.json's "compile" task) nor writable under the container's
+// read-only root filesystem, so it throws PermissionDenied. Open it at
+// config.cache.directory/youtubei.js instead: the same path already
+// granted write access (Dockerfile / docker-compose.yaml).
+//
+// Done lazily because config is only available once parseConfig()
+// resolves in main.ts, and memoized so callers share one handle. On
+// failure the memo is cleared so a later call can retry instead of
+// being stuck on a permanently rejected promise.
+let kvPromise: Promise<Deno.Kv> | undefined;
+
+export const getKv = (config: Config): Promise<Deno.Kv> => {
+    if (!kvPromise) {
+        kvPromise = Deno.openKv(
+            `${config.cache.directory}/youtubei.js/kv_cache.sqlite3`,
+        ).catch((err) => {
+            kvPromise = undefined;
+            throw err;
+        });
+    }
+    return kvPromise;
+};

--- a/src/lib/helpers/kv.ts
+++ b/src/lib/helpers/kv.ts
@@ -8,6 +8,11 @@ import type { Config } from "./config.ts";
 // config.cache.directory/youtubei.js instead: the same path already
 // granted write access (Dockerfile / docker-compose.yaml).
 //
+// The directory is created first because Deno.openKv() does not create
+// parent directories and would otherwise fail with "unable to open
+// database file" when running from source (CI, bare-metal) where the
+// Dockerfile's `mkdir -p /var/tmp/youtubei.js` hasn't run.
+//
 // Done lazily because config is only available once parseConfig()
 // resolves in main.ts, and memoized so callers share one handle. On
 // failure the memo is cleared so a later call can retry instead of
@@ -16,12 +21,13 @@ let kvPromise: Promise<Deno.Kv> | undefined;
 
 export const getKv = (config: Config): Promise<Deno.Kv> => {
     if (!kvPromise) {
-        kvPromise = Deno.openKv(
-            `${config.cache.directory}/youtubei.js/kv_cache.sqlite3`,
-        ).catch((err) => {
-            kvPromise = undefined;
-            throw err;
-        });
+        const cacheDir = `${config.cache.directory}/youtubei.js`;
+        kvPromise = Deno.mkdir(cacheDir, { recursive: true })
+            .then(() => Deno.openKv(`${cacheDir}/kv_cache.sqlite3`))
+            .catch((err) => {
+                kvPromise = undefined;
+                throw err;
+            });
     }
     return kvPromise;
 };

--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -17,8 +17,7 @@ if (Deno.env.get("YT_PLAYER_REQ_LOCATION")) {
 const { youtubePlayerReq } = await import(youtubePlayerReqLocation);
 
 import type { Config } from "./config.ts";
-
-const kv = await Deno.openKv();
+import { getKv } from "./kv.ts";
 
 export const youtubePlayerParsing = async ({
     innertubeClient,
@@ -36,6 +35,7 @@ export const youtubePlayerParsing = async ({
     overrideCache?: boolean;
 }): Promise<object> => {
     const cacheEnabled = overrideCache ? false : config.cache.enabled;
+    const kv = await getKv(config);
 
     const videoCached = (await kv.get(["video_cache", videoId]))
         .value as Uint8Array;


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious-companion/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
Claude Opus 4.8 (diagnosis started on Claude Sonnet 5)

**Tool(s) used:**
Claude Code

**How was AI used?**
AI reproduced the crash locally in Docker under the read-only / dropped-capabilities profile recommended in this repo, read the Deno 2.8→2.9 changelog to pinpoint the behavior change, inspected the compiled binary's `--allow-write` allowlist to confirm the mechanism, then wrote and manually re-verified the fix (rebuilt image, confirmed startup + `/healthz` + KV file creation, ran `deno fmt`/`deno check`). I reviewed the diagnosis and the code, and directed the design: use `config.cache.directory` rather than a raw env read, and extract the logic into a dedicated `helpers/kv.ts` to match the existing helper structure.

---

## Pull request description

Fixes #330

### Problem
`invidious-companion:latest` crash-loops on `Deno.openKv()` (`PermissionDenied (os error 13)`) when run with a read-only root filesystem and dropped capabilities — the exact hardening shown in this repo's own `docker-compose.yaml`.

### Root cause
The Deno `2.8.2 → 2.9.2` bump (#328, commit 064fde8) pulled in [denoland/deno#34618](https://github.com/denoland/deno/pull/34618), which changed what `Deno.openKv()` does with **no path argument inside a compiled binary**: it now resolves a per-app OS data directory (e.g. `$XDG_DATA_HOME`) instead of `DENO_DIR`.

That path is neither in the compiled binary's `--allow-write` allowlist (baked into `deno.json`'s `compile` task) nor writable under the read-only container, so `openKv()` throws and the app never starts. Reproduced locally against the released image under `--cap-drop=ALL --read-only`.

### Fix
Add a dedicated `src/lib/helpers/kv.ts` that opens the store explicitly at `config.cache.directory/youtubei.js/kv_cache.sqlite3` — the path already granted write access in the `Dockerfile` and mounted read-write in `docker-compose.yaml`. It:
- reads the location from `config.cache.directory`, consistent with every other `config.cache.*` read (so both the `CACHE_DIRECTORY` env var and the TOML config file are honored);
- opens lazily, because `config` is only available after `parseConfig()` resolves in `main.ts`;
- memoizes the handle, clearing the memo on failure so a later request can retry instead of being stuck on a permanently rejected promise.

### Testing
- Reproduced the original crash with `quay.io/invidious/invidious-companion:latest` under `--cap-drop=ALL --read-only`.
- Rebuilt the image with this change and ran it under the same restrictive profile: server starts, `/healthz` returns `200`, and the KV sqlite file is created in the writable cache volume.
- `deno fmt --check` and `deno check` pass on the changed files.
