### PR TITLE
Migrate deno.json to deno.jsonc with comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ FROM debian-deno AS builder
 WORKDIR /app
 
 COPY deno.lock ./
-COPY deno.json ./
+COPY deno.jsonc ./
 
 COPY ./src/ ./src/
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,47 +1,71 @@
 {
+  // Deno tasks definitions.
   "tasks": {
+    // Run the server in development mode with file-watching.
     "dev": "deno run --allow-import=github.com:443,jsr.io:443,cdn.jsdelivr.net:443,esm.sh:443,deno.land:443 --allow-net --allow-env --allow-sys=hostname --allow-read=.,/var/tmp/youtubei.js,/tmp/invidious-companion.sock,/tmp/companionsock --allow-write=/var/tmp/youtubei.js,/tmp/invidious-companion.sock,/tmp/companionsock --watch src/main.ts",
+    // Compile a self-contained executable binary.
     "compile": "deno compile --include ./src/lib/helpers/youtubePlayerReq.ts --include ./src/lib/helpers/getFetchClient.ts --output invidious_companion --allow-import=github.com:443,jsr.io:443,cdn.jsdelivr.net:443,esm.sh:443,deno.land:443 --allow-net --allow-env --allow-read --allow-sys=hostname --allow-write=/var/tmp/youtubei.js,/tmp/invidious-companion.sock,/tmp/companionsock src/main.ts --_version_date=\"$(git log -1 --format=%ci | awk '{print $1}' | sed s/-/./g)\" --_version_commit=\"$(git rev-list HEAD --max-count=1 --abbrev-commit)\"",
+    // Run integration tests.
     "test": "deno test --allow-import=github.com:443,jsr.io:443,cdn.jsdelivr.net:443,esm.sh:443,deno.land:443 --allow-net --allow-env --allow-sys=hostname --allow-read=.,/var/tmp/youtubei.js,/tmp/invidious-companion.sock --allow-write=/var/tmp/youtubei.js",
+    // Check code formatting.
     "format": "deno fmt --check src/**",
+    // Type-check the source code without emitting output.
     "check": "deno check src/**",
+    // Lint the source code.
     "lint": "deno lint src/**"
   },
+  // Dependency imports map.
   "imports": {
     "@std/cli": "jsr:@std/cli@^1.0.17",
+    // Web framework.
     "hono": "jsr:@hono/hono@4.7.4",
+    // TOML configuration parser.
     "@std/toml": "jsr:@std/toml@1.0.2",
+    // Prometheus metrics client.
     "prom-client": "https://esm.sh/prom-client@15.1.3?pin=v135",
+    // YouTube.js — InnerTube client for YouTube's private API.
     "youtubei.js": "https://cdn.jsdelivr.net/gh/LuanRT/YouTube.js@v17.2.0-deno/deno.ts",
     "youtubei.js/Utils": "https://cdn.jsdelivr.net/gh/LuanRT/YouTube.js@v17.2.0-deno/deno/src/utils/Utils.ts",
     "youtubei.js/NavigationEndpoint": "https://cdn.jsdelivr.net/gh/LuanRT/YouTube.js@v17.2.0-deno/deno/src/parser/classes/NavigationEndpoint.ts",
     "youtubei.js/PlayerCaptionsTracklist": "https://cdn.jsdelivr.net/gh/LuanRT/YouTube.js@v17.2.0-deno/deno/src/parser/classes/PlayerCaptionsTracklist.ts",
     "youtubei.js/TabbedFeed": "https://cdn.jsdelivr.net/gh/LuanRT/YouTube.js@v17.2.0-deno/deno/src/core/mixins/TabbedFeed.ts",
+    // DOM implementation for Node/Deno (used by YouTube.js).
     "jsdom": "npm:jsdom@26.1.0",
+    // Botguard utilities for PO token generation.
     "bgutils": "https://esm.sh/bgutils-js@3.2.0",
+    // ESTree AST types.
     "estree": "https://esm.sh/@types/estree@1.0.6",
+    // Internal helpers imported in compiled binary.
     "youtubePlayerReq": "./src/lib/helpers/youtubePlayerReq.ts",
     "getFetchClient": "./src/lib/helpers/getFetchClient.ts",
+    // googlevideo URL parsing and n-parameter decryption.
     "googlevideo": "jsr:@luanrt/googlevideo@2.0.0",
+    // JavaScript parser (for YouTube challenges).
     "meriyah": "npm:meriyah@6.1.4",
+    // Compression (used for chunked responses).
     "fflate": "npm:fflate@0.8.2",
     "crypto/": "https://deno.land/x/crypto@v0.11.0/",
     "@std/encoding/base64": "jsr:@std/encoding@1.0.7/base64",
     "@std/async": "jsr:@std/async@1.0.11",
     "@std/fs": "jsr:@std/fs@1.0.14",
     "@std/path": "jsr:@std/path@1.0.8",
+    // Brotli decompression for compressed responses.
     "brotli": "https://deno.land/x/brotli@0.1.7/mod.ts",
+    // Schema validation for configuration.
     "zod": "https://deno.land/x/zod@v3.24.2/mod.ts",
+    // Stubs for Node-specific dependencies not used in Deno.
     "canvas": "./src/lib/extra/emptyExport.ts",
     "bufferutil": "./src/lib/extra/emptyExport.ts",
     "utf-8-validate": "./src/lib/extra/emptyExport.ts"
   },
+  // Unstable Deno APIs used by the application.
   "unstable": [
     "cron",
     "kv",
     "http",
     "temporal"
   ],
+  // Formatter configuration.
   "fmt": {
     "indentWidth": 4
   }

--- a/src/lib/helpers/kv.ts
+++ b/src/lib/helpers/kv.ts
@@ -3,7 +3,7 @@ import type { Config } from "./config.ts";
 // Deno 2.9 moved the no-argument Deno.openKv() default store to a
 // per-app OS data directory (e.g. $XDG_DATA_HOME) instead of DENO_DIR,
 // which is neither in the compiled binary's --allow-write allowlist
-// (see deno.json's "compile" task) nor writable under the container's
+// (see deno.jsonc's "compile" task) nor writable under the container's
 // read-only root filesystem, so it throws PermissionDenied. Open it at
 // config.cache.directory/youtubei.js instead: the same path already
 // granted write access (Dockerfile / docker-compose.yaml).


### PR DESCRIPTION
Closes #227

## Description
Rename `deno.json` to `deno.jsonc` to enable comments in the Deno configuration file, making it easier to document the purpose of each dependency and configuration setting.

### Changes
- Renamed `deno.json` to `deno.jsonc`
- Added explanatory comments for tasks, imports, unstable APIs, and formatter settings
- Updated `Dockerfile` to copy `deno.jsonc` instead of `deno.json`
- Updated comment in `src/lib/helpers/kv.ts` to reference the new filename

## AI Disclosure
- Model: deepseek-v4-pro
- Tool: opencode