### PR TITLE
Tag container images with sortable date prefix on master

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -57,7 +57,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
-            type=sha,prefix={{branch}}-
+            type=sha,format=short,prefix={{date 'YYYY.MM.DD'}}-,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
           # Define labels
           labels: |
             quay.expires-after=12w


### PR DESCRIPTION
Closes #265

## Description
Use `YYYY.MM.DD-<shortsha>` format for master branch image tags instead of `master-<fullsha>`, matching the [Invidious upstream](https://github.com/iv-org/invidious) tagging convention. This makes image tags chronologically sortable for tools like Renovate.

### Changes
- Changed `type=sha,prefix={{branch}}-` to `type=sha,format=short,prefix={{date 'YYYY.MM.DD'}}-,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}`
- SHA format changed from full hash to short hash (matching upstream convention)
- Date-prefix tag only enabled on master branch (semver tags unchanged for releases)

### Before
`master-607cb8d`

### After
`2026.07.14-a1b2c3d`

## AI Disclosure
- Model: deepseek-v4-pro
- Tool: opencode