### PR TITLE
fix: fall back to in-memory KV when the on-disk store is unwritable

### DIFF
--- a/src/lib/helpers/kv.ts
+++ b/src/lib/helpers/kv.ts
@@ -14,9 +14,16 @@ import type { Config } from "./config.ts";
 // Dockerfile's `mkdir -p /var/tmp/youtubei.js` hasn't run.
 //
 // Done lazily because config is only available once parseConfig()
-// resolves in main.ts, and memoized so callers share one handle. On
-// failure the memo is cleared so a later call can retry instead of
-// being stuck on a permanently rejected promise.
+// resolves in main.ts, and memoized so callers share one handle.
+//
+// If the on-disk store cannot be written (e.g. a read-only filesystem
+// where neither the cache directory nor its parent is writable), fall
+// back to an ephemeral in-memory KV store (the special ":memory:" path,
+// see https://docs.deno.com/api/deno/~/Deno.openKv). This keeps the app
+// running instead of crash-looping; the cache is simply not persisted
+// across restarts. A warning is logged so the misconfiguration is
+// visible. The in-memory store always succeeds, so once the fallback is
+// taken it is memoized like the on-disk handle.
 let kvPromise: Promise<Deno.Kv> | undefined;
 
 export const getKv = (config: Config): Promise<Deno.Kv> => {
@@ -25,8 +32,11 @@ export const getKv = (config: Config): Promise<Deno.Kv> => {
         kvPromise = Deno.mkdir(cacheDir, { recursive: true })
             .then(() => Deno.openKv(`${cacheDir}/kv_cache.sqlite3`))
             .catch((err) => {
-                kvPromise = undefined;
-                throw err;
+                console.error(
+                    `[WARN] Failed to open the on-disk KV cache at ${cacheDir}/kv_cache.sqlite3, falling back to an in-memory store (cache will not persist across restarts)`,
+                    err,
+                );
+                return Deno.openKv(":memory:");
             });
     }
     return kvPromise;


### PR DESCRIPTION
## Checklist

- [x] I have read the [AI Policy](https://github.com/iv-org/invidious-companion/blob/master/AI_POLICY.md) and understand the disclosure requirements


## AI Disclosure

<!-- Tick exactly one -->

- [ ] AI was not used to create this pull request
- [ ] AI was used to fully create this pull request
- [x] AI was used to partially create this pull request

<!-- Leave the following section blank if you didn't use AI -->

**Model(s) used (and thinking/reasoning level if relevant):**
Claude Opus 4.8 (1M context)

**Tool(s) used:**
Claude Code

**How was AI used?**
AI investigated the crash-loop reported in #348, looked up the Deno KV in-memory API, wrote the fallback code and this description. The approach and review were directed by a human.

---

## Pull request description

Fixes #348.

Even after #329 / 38e9ddb (which creates the cache directory before opening the store), `Deno.openKv()` can still fail with `unable to open database file: /var/tmp/youtubei.js/kv_cache.sqlite3` — for example on a read-only filesystem where the cache directory or its parent is not writable. When that happens, PO token validation crash-loops and no video can be watched.

This change catches the failure and falls back to an ephemeral in-memory KV store using the special [`":memory:"` path](https://docs.deno.com/api/deno/~/Deno.openKv). The app keeps running (the cache is simply not persisted across restarts), and a warning is logged so the underlying filesystem misconfiguration stays visible.